### PR TITLE
feat(v2): extract network and scanning from monolith

### DIFF
--- a/retro_refiner/cli.py
+++ b/retro_refiner/cli.py
@@ -9,21 +9,9 @@ import tempfile
 from pathlib import Path
 
 from retro_refiner.config import Config, load_config, save_config
-from retro_refiner.network import is_url, validate_source, scan_network_source
+from retro_refiner.network import format_size, is_url, validate_source
+from retro_refiner.scanner import scan_network_source
 from retro_refiner.paths import get_runtime_path
-
-
-def format_size(size_bytes: int) -> str:
-    """Format bytes as human-readable string."""
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    if size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    if size_bytes < 1024 * 1024 * 1024:
-        return f"{size_bytes / 1024 / 1024:.1f} MB"
-    if size_bytes < 1024 * 1024 * 1024 * 1024:
-        return f"{size_bytes / 1024 / 1024 / 1024:.2f} GB"
-    return f"{size_bytes / 1024 / 1024 / 1024 / 1024:.2f} TB"
 
 
 def run_headless(args: list):

--- a/retro_refiner/network.py
+++ b/retro_refiner/network.py
@@ -1,89 +1,701 @@
-"""Network operations: URL handling, HTML scraping, source scanning.
+"""Network operations: URL handling, HTML scraping, source validation.
 
-Wraps the monolith's network functions with clean APIs.
+Standalone implementations extracted from the monolith. No Console/Style
+dependencies — output goes through callbacks or plain stderr.
 """
+import json
+import re
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
-from retro_refiner.models import ProgressEvent, ScanResult
+# ---------------------------------------------------------------------------
+# Shutdown mechanism
+# ---------------------------------------------------------------------------
 
+_shutdown_event = threading.Event()
+
+
+def request_shutdown():
+    """Signal all network operations to stop."""
+    _shutdown_event.set()
+
+
+def check_shutdown():
+    """Raise SystemExit if shutdown was requested."""
+    if _shutdown_event.is_set():
+        raise SystemExit("Shutdown requested")
+
+
+def reset_shutdown():
+    """Clear the shutdown flag (useful between runs / in tests)."""
+    _shutdown_event.clear()
+
+
+# ---------------------------------------------------------------------------
+# Size / URL formatting helpers
+# ---------------------------------------------------------------------------
+
+def format_size(size_bytes: int) -> str:
+    """Format a size in bytes to a human-readable string."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    if size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
+
+
+def format_url(url: str, max_length: int = 0) -> str:
+    """Format a URL for display: decode percent-encoding for readability."""
+    decoded = urllib.request.unquote(url)
+    if 0 < max_length < len(decoded):
+        return decoded[:max_length - 3] + "..."
+    return decoded
+
+
+# ---------------------------------------------------------------------------
+# URL utilities
+# ---------------------------------------------------------------------------
 
 def is_url(source: str) -> bool:
     """Check if a source string is a URL."""
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().is_url(source)
+    return source.startswith('http://') or source.startswith('https://')
 
+
+def parse_url(url: str) -> Tuple[str, str, str]:
+    """Parse URL into (scheme, host, path) components."""
+    if '://' in url:
+        scheme, rest = url.split('://', 1)
+    else:
+        scheme = 'https'
+        rest = url
+
+    if '/' in rest:
+        host, path = rest.split('/', 1)
+        path = '/' + path
+    else:
+        host = rest
+        path = '/'
+
+    return scheme, host, path
+
+
+def normalize_url(href: str, base_url: str) -> Optional[str]:
+    """Normalize a URL reference relative to a base URL.
+
+    Handles relative paths, absolute paths, and full URLs.
+    Returns None if the URL should be skipped.
+    """
+    # Decode HTML entities
+    href = href.replace('&amp;', '&')
+
+    # Skip empty, anchors, javascript, mailto, data URIs
+    if not href or href.startswith('#') or href.startswith('javascript:') or \
+       href.startswith('mailto:') or href.startswith('data:'):
+        return None
+
+    # Skip parent directory links
+    if href in ('.', '..', '../', './'):
+        return None
+
+    # Skip query-only links
+    if href.startswith('?'):
+        return None
+
+    # Parse base URL
+    base_scheme, base_host, base_path = parse_url(base_url)
+
+    # Ensure base path ends with /
+    if not base_path.endswith('/'):
+        base_path = base_path.rsplit('/', 1)[0] + '/'
+
+    # Handle different URL types
+    if href.startswith('//'):
+        return f"{base_scheme}:{href}"
+
+    if href.startswith('http://') or href.startswith('https://'):
+        _, href_host, _ = parse_url(href)
+        if href_host.lower() != base_host.lower():
+            return None
+        return href
+
+    if href.startswith('/'):
+        return f"{base_scheme}://{base_host}{href}"
+
+    # Relative path
+    path_parts = [p for p in base_path.split('/') if p]
+    href_parts = href.split('/')
+
+    for part in href_parts:
+        if part == '..':
+            if path_parts:
+                path_parts.pop()
+        elif part in ('', '.'):
+            continue
+        else:
+            path_parts.append(part)
+
+    resolved_path = '/' + '/'.join(path_parts)
+    return f"{base_scheme}://{base_host}{resolved_path}"
+
+
+# ---------------------------------------------------------------------------
+# ROM extension constants
+# ---------------------------------------------------------------------------
+
+ROM_EXTENSIONS = (
+    '.zip', '.7z', '.rar', '.sfc', '.smc', '.nes', '.fds', '.gb', '.gbc',
+    '.gba', '.n64', '.z64', '.v64', '.md', '.gen', '.smd', '.sms', '.gg',
+    '.pce', '.col', '.a26', '.a52', '.a78', '.j64', '.jag', '.lnx',
+    '.vb', '.ws', '.wsc', '.mx1', '.mx2', '.32x', '.sg', '.vec',
+    '.int', '.st', '.gcm', '.gcz', '.rvz', '.wbfs', '.iso', '.cue',
+    '.chd', '.nds', '.3ds', '.cia', '.nsp', '.xci', '.pbp', '.cso',
+    '.ngp', '.ngc', '.neo', '.pco', '.min', '.ndd', '.fcf'
+)
+
+
+# ---------------------------------------------------------------------------
+# HTML link extraction and parsing
+# ---------------------------------------------------------------------------
+
+def extract_links_from_html(html: str) -> List[str]:
+    """Extract all potential file/directory links from HTML content."""
+    links = []
+
+    href_pattern = re.compile(
+        r'href\s*=\s*["\']?([^"\'<>\s]+)["\']?',
+        re.IGNORECASE
+    )
+    src_pattern = re.compile(
+        r'src\s*=\s*["\']([^"\'<>]+)["\']',
+        re.IGNORECASE
+    )
+    data_pattern = re.compile(
+        r'data-(?:url|href|src|link|file)\s*=\s*["\']([^"\'<>]+)["\']',
+        re.IGNORECASE
+    )
+    url_pattern = re.compile(
+        r'(?:^|\s|>)(/[^\s<>"\']+\.[a-zA-Z0-9]{2,4})(?:\s|<|$)',
+        re.MULTILINE
+    )
+    onclick_pattern = re.compile(
+        r'on(?:click|mousedown)\s*=\s*["\'][^"\']*'
+        r'(?:location\.href\s*=\s*|window\.open\s*\()["\']([^"\']+)["\']',
+        re.IGNORECASE
+    )
+    text_file_pattern = re.compile(
+        r'(?:^|\s)([A-Za-z0-9][\w\s\-\.\(\)\[\]]+\.(?:' +
+        '|'.join(ext[1:] for ext in ROM_EXTENSIONS) +
+        r'))(?:\s|$)',
+        re.IGNORECASE | re.MULTILINE
+    )
+
+    for match in href_pattern.finditer(html):
+        links.append(match.group(1))
+    for match in src_pattern.finditer(html):
+        link = match.group(1)
+        if any(link.lower().endswith(ext) for ext in ROM_EXTENSIONS):
+            links.append(link)
+    for match in data_pattern.finditer(html):
+        links.append(match.group(1))
+    for match in onclick_pattern.finditer(html):
+        links.append(match.group(1))
+    for match in url_pattern.finditer(html):
+        links.append(match.group(1))
+
+    pre_sections = re.findall(
+        r'<(?:pre|code|listing)[^>]*>(.*?)</(?:pre|code|listing)>',
+        html, re.IGNORECASE | re.DOTALL
+    )
+    for section in pre_sections:
+        for match in text_file_pattern.finditer(section):
+            links.append(match.group(1))
+
+    return links
+
+
+def is_rom_file(filename: str) -> bool:
+    """Check if a filename appears to be a ROM file."""
+    clean_name = filename.split('?')[0].split('#')[0]
+    lower_name = clean_name.lower()
+    try:
+        lower_name = urllib.request.unquote(lower_name)
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return any(lower_name.endswith(ext) for ext in ROM_EXTENSIONS)
+
+
+def is_directory_link(href: str) -> bool:
+    """Check if a link appears to be a directory."""
+    clean = href.split('?')[0].split('#')[0]
+    if clean.endswith('/'):
+        return True
+    last_part = clean.rstrip('/').split('/')[-1]
+    if '.' not in last_part and last_part not in ('', '.', '..'):
+        return not any(last_part.lower().endswith(ext) for ext in ROM_EXTENSIONS)
+    return False
+
+
+def parse_size_string(size_str: str) -> int:
+    """Parse a human-readable size string into bytes.
+
+    Handles formats like: 1.5M, 100K, 50G, 1.5 MB, 100 KB, 175.9 MiB, 1536000
+    """
+    if not size_str:
+        return 0
+
+    size_str = size_str.strip().upper()
+
+    try:
+        return int(size_str)
+    except ValueError:
+        pass
+
+    match = re.match(r'^([\d.]+)\s*([KMGT])I?B?$', size_str)
+    if not match:
+        return 0
+
+    try:
+        value = float(match.group(1))
+        unit = match.group(2) or ''
+        multipliers = {
+            '': 1,
+            'K': 1024,
+            'M': 1024 * 1024,
+            'G': 1024 * 1024 * 1024,
+            'T': 1024 * 1024 * 1024 * 1024,
+        }
+        return int(value * multipliers.get(unit, 1))
+    except (ValueError, TypeError):
+        return 0
+
+
+def extract_file_sizes_from_html(html: str) -> Dict[str, int]:
+    """Extract file sizes from HTML directory listings.
+
+    Returns dict mapping filename -> size in bytes.
+    """
+    sizes: Dict[str, int] = {}
+
+    # Pattern 1: Myrient/structured table format
+    myrient_pattern = re.compile(
+        r'<td[^>]*class="link"[^>]*>\s*<a\s+href="([^"]+)"[^>]*>([^<]+)</a>\s*</td>\s*'
+        r'<td[^>]*class="size"[^>]*>\s*([\d.]+\s*[KMGT]i?B|[\d.]+|-)\s*</td>',
+        re.IGNORECASE
+    )
+
+    myrient_matched = False
+    for match in myrient_pattern.finditer(html):
+        myrient_matched = True
+        href = match.group(1)
+        filename = match.group(2).strip()
+        size_str = match.group(3).strip()
+
+        if size_str != '-':
+            size = parse_size_string(size_str)
+            if size > 0:
+                clean_href = urllib.request.unquote(href.split('?')[0].split('#')[0])
+                sizes[clean_href] = size
+                sizes[filename] = size
+
+    if myrient_matched:
+        return sizes
+
+    # Pattern 2: Apache/nginx autoindex format
+    autoindex_pattern = re.compile(
+        r'<a\s+href=["\']?([^"\'<>\s]+)["\']?[^>]*>([^<]+)</a>\s*'
+        r'(?:\d{1,2}[-/]\w{3}[-/]\d{2,4}\s+\d{1,2}:\d{2}'
+        r'|\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})\s*'
+        r'([\d.]+\s*[KMGT]i?B?|\d+|-)',
+        re.IGNORECASE
+    )
+
+    for match in autoindex_pattern.finditer(html):
+        href = match.group(1)
+        size_str = match.group(3).strip()
+        if size_str != '-':
+            size = parse_size_string(size_str)
+            if size > 0:
+                filename = match.group(2).strip()
+                clean_href = urllib.request.unquote(href.split('?')[0].split('#')[0])
+                sizes[clean_href] = size
+                sizes[filename] = size
+
+    if sizes:
+        return sizes
+
+    # Pattern 3: Generic table format with size in separate cell
+    table_row_pattern = re.compile(
+        r'<tr[^>]*>.*?<a\s+href=["\']?([^"\'<>\s]+)["\']?[^>]*>([^<]+)</a>.*?'
+        r'<td[^>]*>\s*([\d.]+\s*[KMGT]i?B?|\d+)\s*</td>.*?</tr>',
+        re.IGNORECASE | re.DOTALL
+    )
+
+    for match in table_row_pattern.finditer(html):
+        href = match.group(1)
+        filename = match.group(2).strip()
+        size_str = match.group(3).strip()
+        size = parse_size_string(size_str)
+        if size > 0:
+            clean_href = urllib.request.unquote(href.split('?')[0].split('#')[0])
+            sizes[clean_href] = size
+            sizes[filename] = size
+
+    # Pattern 4: Pre/listing block with sizes (FTP-style)
+    pre_sections = re.findall(
+        r'<(?:pre|code|listing)[^>]*>(.*?)</(?:pre|code|listing)>',
+        html, re.IGNORECASE | re.DOTALL
+    )
+
+    for section in pre_sections:
+        ftp_pattern = re.compile(
+            r'[-drwx]{10}\s+\d+\s+\S+\s+\S+\s+(\d+)\s+\w+\s+\d+\s+[\d:]+\s+(\S+)',
+            re.MULTILINE
+        )
+        for match in ftp_pattern.finditer(section):
+            size = int(match.group(1))
+            filename = match.group(2)
+            if size > 0:
+                sizes[filename] = size
+
+        simple_pattern = re.compile(
+            r'(\S+\.(?:zip|7z|rar|iso|chd|cue|bin))\s+(\d+)',
+            re.IGNORECASE
+        )
+        for match in simple_pattern.finditer(section):
+            filename = match.group(1)
+            size = int(match.group(2))
+            if size > 0:
+                sizes[filename] = size
+
+    return sizes
+
+
+def get_filename_from_url(url: str) -> str:
+    """Extract and decode filename from a URL."""
+    url_clean = url.split('?')[0].split('#')[0]
+    filename = urllib.request.unquote(url_clean.split('/')[-1])
+    return filename
+
+
+def parse_html_for_files(html: str, base_url: str) -> List[str]:
+    """Parse HTML content and extract ROM file URLs."""
+    files = []
+    seen: set = set()
+
+    links = extract_links_from_html(html)
+
+    for href in links:
+        url = normalize_url(href, base_url)
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        if is_rom_file(url):
+            files.append(url)
+
+    return files
+
+
+def parse_html_for_files_with_sizes(html: str, base_url: str) -> List[Tuple[str, int]]:
+    """Parse HTML content and extract ROM file URLs with their sizes.
+
+    Returns list of (url, size) tuples. Size is 0 if unknown.
+    """
+    files = []
+    seen: set = set()
+
+    size_map = extract_file_sizes_from_html(html)
+    links = extract_links_from_html(html)
+
+    for href in links:
+        url = normalize_url(href, base_url)
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        if is_rom_file(url):
+            filename = get_filename_from_url(url)
+            size = size_map.get(filename, 0) or size_map.get(href, 0)
+            files.append((url, size))
+
+    return files
+
+
+def parse_html_for_directories(html: str, base_url: str) -> List[str]:
+    """Parse HTML content and extract subdirectory URLs."""
+    dirs = []
+    seen: set = set()
+
+    links = extract_links_from_html(html)
+
+    for href in links:
+        if not is_directory_link(href):
+            continue
+        url = normalize_url(href, base_url)
+        if not url:
+            continue
+        if not url.endswith('/'):
+            url += '/'
+        if url in seen or url == base_url or url == base_url.rstrip('/') + '/':
+            continue
+        base_normalized = base_url.rstrip('/') + '/'
+        if not url.startswith(base_normalized):
+            continue
+        seen.add(url)
+        dirs.append(url)
+
+    return dirs
+
+
+# ---------------------------------------------------------------------------
+# Source validation
+# ---------------------------------------------------------------------------
 
 def validate_source(source: str, timeout: int = 15) -> Tuple[bool, str]:
     """Validate a source path or URL is accessible.
 
     Returns (is_valid, message) tuple.
     """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().validate_source(source, timeout)
+    if is_url(source):
+        try:
+            request = urllib.request.Request(
+                source,
+                headers={
+                    'User-Agent': 'Mozilla/5.0 (compatible; Retro-Refiner/1.0)',
+                    'Accept': 'text/html,application/xhtml+xml,*/*',
+                }
+            )
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                if response.status == 200:
+                    return True, ""
+                return False, f"HTTP {response.status}"
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return False, "Not found (404)"
+            if exc.code == 403:
+                return False, "Access denied (403)"
+            if exc.code == 401:
+                return False, "Authentication required (401)"
+            return False, f"HTTP error {exc.code}"
+        except urllib.error.URLError as exc:
+            return False, f"Connection failed: {exc.reason}"
+        except socket.timeout:
+            return False, "Connection timed out"
+        except Exception as exc:  # pylint: disable=broad-except
+            return False, str(exc)
+    else:
+        path = Path(source)
+        if not path.exists():
+            return False, "Path does not exist"
+        if not path.is_dir():
+            return False, "Path is not a directory"
+        return True, ""
 
 
-def scan_network_source(url: str, systems: List[str] = None,
-                        recursive: bool = True, max_depth: int = 3,
-                        auth_header: str = None, scan_workers: int = 16,
-                        cache_dir: Path = None, no_cache: bool = False,
-                        on_progress: Callable = None) -> ScanResult:
-    """Scan a network source for ROM URLs.
+def validate_all_sources(local_sources: List[Path],
+                         network_sources: List[str]) -> List[Tuple[str, str]]:
+    """Validate all sources are accessible.
 
-    Returns structured ScanResult instead of printing to stdout.
-    Uses scan cache if available and fresh.
-
-    Args:
-        url: Base URL to scan.
-        systems: Optional list of system codes to filter for.
-        recursive: Whether to follow subdirectories.
-        max_depth: Maximum directory traversal depth.
-        auth_header: Optional HTTP auth header value.
-        scan_workers: Number of concurrent scan workers.
-        cache_dir: Directory for scan cache files.
-        no_cache: If True, bypass scan cache.
-        on_progress: Optional callback for progress updates.
+    Returns list of (source, error_message) tuples for failed sources.
     """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    mod = get_module()
+    errors = []
 
-    # Check cache first
-    if cache_dir and not no_cache:
-        cached = mod.load_scan_cache(cache_dir, url)
-        if cached:
-            url_dict, url_sizes = cached
-            if on_progress:
-                total = sum(len(urls) for urls in url_dict.values())
-                on_progress(ProgressEvent(
-                    phase="complete",
-                    message=f"Using cached scan ({total} URLs)"
-                ))
-            return ScanResult(url_dict=url_dict, url_sizes=url_sizes)
+    for source in local_sources:
+        success, error = validate_source(str(source))
+        if not success:
+            errors.append((str(source), error))
 
-    # Full scan
-    url_dict, url_sizes = mod.scan_network_source_urls(
-        url, systems,
-        recursive=recursive,
-        max_depth=max_depth,
-        auth_header=auth_header,
-        scan_workers=scan_workers
+    for source in network_sources:
+        print(f"Validating: {format_url(source)}...", end=" ", flush=True)
+        success, error = validate_source(source)
+        if success:
+            print("OK")
+        else:
+            print(f"FAILED ({error})")
+            errors.append((source, error))
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# URL fetching
+# ---------------------------------------------------------------------------
+
+def fetch_url(url: str, timeout: int = 30, max_redirects: int = 5,
+              auth_header: Optional[str] = None) -> Tuple[bytes, str]:
+    """Fetch content from a URL, following redirects.
+
+    Returns (content, final_url) tuple.
+    """
+    current_url = url
+    redirects = 0
+
+    while redirects < max_redirects:
+        try:
+            headers = {
+                'User-Agent': 'Mozilla/5.0 (compatible; Retro-Refiner/1.0)',
+                'Accept': 'text/html,application/xhtml+xml,*/*',
+                'Accept-Language': 'en-US,en;q=0.9',
+            }
+            if auth_header:
+                headers['Authorization'] = auth_header
+            request = urllib.request.Request(current_url, headers=headers)
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                final_url = response.geturl()
+
+                if 'archive.org/account/' in final_url:
+                    raise Exception(  # pylint: disable=broad-exception-raised
+                        "Archive.org requires authentication.\n"
+                        "Get credentials at: https://archive.org/account/s3.php\n"
+                        "Then set: export IA_ACCESS_KEY=your_key\n"
+                        "         export IA_SECRET_KEY=your_secret"
+                    )
+
+                return response.read(), final_url
+        except urllib.error.HTTPError as exc:
+            if exc.code in (301, 302, 303, 307, 308):
+                new_url = exc.headers.get('Location')
+                if new_url:
+                    if 'archive.org/account/' in new_url:
+                        raise Exception(  # pylint: disable=broad-exception-raised
+                            "Archive.org requires authentication.\n"
+                            "Get credentials at: https://archive.org/account/s3.php\n"
+                            "Then set: export IA_ACCESS_KEY=your_key\n"
+                            "         export IA_SECRET_KEY=your_secret"
+                        ) from exc
+                    current_url = normalize_url(new_url, current_url) or new_url
+                    redirects += 1
+                    continue
+            raise
+
+    raise Exception(  # pylint: disable=broad-exception-raised
+        f"Too many redirects for {url}"
     )
 
-    # Save to cache
-    if cache_dir and not no_cache:
-        mod.save_scan_cache(cache_dir, url, dict(url_dict), url_sizes)
 
-    return ScanResult(url_dict=dict(url_dict), url_sizes=url_sizes)
+def fetch_urls_parallel(urls: List[str], max_workers: int = 16,
+                        auth_header: Optional[str] = None,
+                        progress_callback=None) -> Dict[str, Tuple[bytes, str]]:
+    """Fetch multiple URLs in parallel using ThreadPoolExecutor.
+
+    Returns dict of {url: (content, final_url)} for successful fetches.
+    """
+    results: Dict[str, Tuple[bytes, str]] = {}
+
+    if not urls:
+        return results
+
+    def _fetch_one(target_url):
+        try:
+            check_shutdown()
+            content, final_url = fetch_url(target_url, auth_header=auth_header)
+            return target_url, (content, final_url), None
+        except Exception as exc:  # pylint: disable=broad-except
+            return target_url, None, str(exc)
+
+    actual_workers = min(max_workers, len(urls))
+
+    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+        futures = {executor.submit(_fetch_one, u): u for u in urls}
+        completed = 0
+        for future in as_completed(futures):
+            completed += 1
+            if progress_callback:
+                progress_callback(completed, len(urls))
+            target_url, result, _error = future.result()
+            if result:
+                results[target_url] = result
+
+    return results
 
 
-def get_ia_auth_header(access_key: str = None,
-                       secret_key: str = None) -> Optional[str]:
-    """Build Internet Archive authentication header."""
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().get_ia_auth_header(access_key, secret_key)
-
+# ---------------------------------------------------------------------------
+# Archive.org / T-En / Myrient helpers
+# ---------------------------------------------------------------------------
 
 def is_archive_org_url(url: str) -> bool:
-    """Check if URL is an Archive.org source."""
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().is_archive_org_url(url)
+    """Check if URL is from Internet Archive (archive.org)."""
+    return 'archive.org/' in url.lower()
+
+
+def get_ia_auth_header(access_key: Optional[str] = None,
+                       secret_key: Optional[str] = None) -> Optional[str]:
+    """Build Internet Archive S3-style authorization header."""
+    if access_key and secret_key:
+        return f'LOW {access_key}:{secret_key}'
+    return None
+
+
+def is_ten_source(url: str) -> bool:
+    """Check if a URL is a T-En (translation) collection source."""
+    url_decoded = urllib.request.unquote(url).lower()
+    return '[t-en]' in url_decoded or 't-en collection' in url_decoded
+
+
+def is_myrient_tosec_url(url: str) -> bool:
+    """Check if a URL is a Myrient TOSEC source."""
+    return 'myrient.erista.me/files/TOSEC/' in url
+
+
+# ---------------------------------------------------------------------------
+# Scan cache
+# ---------------------------------------------------------------------------
+
+SCAN_CACHE_FILE = '_scan_cache.json'
+SCAN_CACHE_MAX_AGE = 86400  # 24 hours
+
+
+def load_scan_cache(cache_dir: Path,
+                    url: str) -> Optional[Tuple[Dict[str, List[str]], Dict[str, int]]]:
+    """Load cached network scan results if fresh (< 24h old)."""
+    cache_path = cache_dir / SCAN_CACHE_FILE
+    if not cache_path.exists():
+        return None
+    try:
+        with open(cache_path, 'r', encoding='utf-8') as fh:
+            cache = json.load(fh)
+        entry = cache.get(url)
+        if not entry:
+            return None
+        age = time.time() - entry.get('timestamp', 0)
+        if age > SCAN_CACHE_MAX_AGE:
+            return None
+        url_dict = entry.get('urls', {})
+        url_sizes = entry.get('sizes', {})
+        return url_dict, url_sizes
+    except (json.JSONDecodeError, IOError, KeyError):
+        return None
+
+
+def save_scan_cache(cache_dir: Path, url: str,
+                    url_dict: Dict[str, List[str]],
+                    url_sizes: Dict[str, int]):
+    """Save network scan results to cache."""
+    cache_path = cache_dir / SCAN_CACHE_FILE
+    cache: dict = {}
+    if cache_path.exists():
+        try:
+            with open(cache_path, 'r', encoding='utf-8') as fh:
+                cache = json.load(fh)
+        except (json.JSONDecodeError, IOError):
+            cache = {}
+    now = time.time()
+    cache = {k: v for k, v in cache.items()
+             if now - v.get('timestamp', 0) < SCAN_CACHE_MAX_AGE}
+    cache[url] = {
+        'timestamp': now,
+        'urls': url_dict,
+        'sizes': url_sizes,
+    }
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        with open(cache_path, 'w', encoding='utf-8') as fh:
+            json.dump(cache, fh)
+    except IOError:
+        pass

--- a/retro_refiner/scanner.py
+++ b/retro_refiner/scanner.py
@@ -1,18 +1,512 @@
-"""Source scanning: discover systems and ROM files from local and network sources."""
+"""Source scanning: discover systems and ROM files from local and network sources.
+
+Standalone implementations extracted from the monolith. Console output is
+replaced by an ``on_progress`` callback and plain stderr for errors.
+"""
+import re
+import sys
+import time
+import urllib.request
+from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
-from retro_refiner.models import ProgressEvent, SystemScanInfo
+from retro_refiner.models import ProgressEvent, ScanResult, SystemScanInfo
+from retro_refiner.network import (
+    check_shutdown,
+    fetch_url,
+    fetch_urls_parallel,
+    format_size,
+    format_url,
+    load_scan_cache,
+    parse_html_for_directories,
+    parse_html_for_files_with_sizes,
+    save_scan_cache,
+)
+from retro_refiner.systems import load_system_data
 
+
+# ---------------------------------------------------------------------------
+# Progress bar (simplified — no Style/Console dependency)
+# ---------------------------------------------------------------------------
+
+class ScanProgressBar:
+    """Progress bar for parallel scanning operations with callback interface."""
+
+    def __init__(self, total: int, desc: str = 'Scanning', indent: str = ''):
+        self.total = total
+        self.desc = desc
+        self.indent = indent
+        self.current = 0
+        self.start_time = time.time()
+        self.bar_width = 20
+        self._print_bar()
+
+    def update(self, completed: int):
+        """Update progress to specific count."""
+        self.current = completed
+        self._print_bar()
+
+    @staticmethod
+    def _format_time(seconds):
+        """Format seconds into human-readable string."""
+        if seconds < 60:
+            return f"{seconds:.0f}s"
+        if seconds < 3600:
+            mins, secs = divmod(int(seconds), 60)
+            return f"{mins}:{secs:02d}"
+        hours, remainder = divmod(int(seconds), 3600)
+        mins, secs = divmod(remainder, 60)
+        return f"{hours}:{mins:02d}:{secs:02d}"
+
+    def _print_bar(self):
+        elapsed = time.time() - self.start_time
+
+        if self.total > 0:
+            pct = self.current / self.total
+            filled = int(self.bar_width * pct)
+            bar = '#' * filled + '-' * (self.bar_width - filled)
+
+            if self.current > 0 and elapsed > 0:
+                rate = self.current / elapsed
+                remaining = (self.total - self.current) / rate if rate > 0 else 0
+                rate_str = f"{rate:.1f}" if rate < 100 else f"{rate:.0f}"
+                eta_str = self._format_time(remaining)
+                elapsed_str = self._format_time(elapsed)
+                stats = f" [{elapsed_str}<{eta_str}, {rate_str}/s]"
+            else:
+                stats = ""
+
+            line = (f"\r{self.indent}{self.desc}: "
+                    f"|{bar}| {self.current}/{self.total}{stats}")
+        else:
+            line = f"\r{self.indent}{self.desc}: {self.current}"
+
+        print(f"{line:<79}", end='', flush=True)
+
+    def finish(self, message: str = None):
+        """Finish progress bar and optionally print a completion message."""
+        print('\r' + ' ' * 79 + '\r', end='', flush=True)
+        if message:
+            print(f"{self.indent}{message}")
+
+    def make_callback(self):
+        """Return a callback function for use with fetch_urls_parallel."""
+        def callback(completed, _total):
+            self.update(completed)
+        return callback
+
+
+# ---------------------------------------------------------------------------
+# System detection from URL path
+# ---------------------------------------------------------------------------
 
 def detect_system_from_path(path: str) -> Optional[str]:
     """Detect system from a URL path or folder name.
 
-    Returns the system code string, or None if not detected.
+    Handles No-Intro style names like ``GCE - Vectrex`` and simple names
+    like ``vectrex``.
     """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().detect_system_from_path(path)
+    sysdata = load_system_data()
+    path_decoded = urllib.request.unquote(path)
 
+    for part in path_decoded.split('/'):
+        part_clean = part.strip()
+        if not part_clean:
+            continue
+
+        part_lower = part_clean.lower()
+
+        if part_lower in sysdata.folder_aliases:
+            return sysdata.folder_aliases[part_lower]
+        if part_lower in sysdata.known_systems:
+            return part_lower
+
+        if part_lower in sysdata.dat_name_to_system:
+            return sysdata.dat_name_to_system[part_lower]
+
+        for dat_name, system in sysdata.sorted_dat_names:
+            if dat_name in part_lower:
+                return system
+
+        part_normalized = re.sub(r'[^a-z0-9]', '', part_lower)
+        for alias, system in sysdata.sorted_aliases:
+            alias_normalized = re.sub(r'[^a-z0-9]', '', alias)
+            if len(alias_normalized) >= 4 and alias_normalized in part_normalized:
+                return system
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Network source scanning (full implementation)
+# ---------------------------------------------------------------------------
+
+def _log(msg: str, on_progress: Callable = None):
+    """Emit a progress message via callback, or fall through to print."""
+    if on_progress:
+        on_progress(ProgressEvent(phase="scanning", message=msg))
+    else:
+        print(msg, flush=True)
+
+
+def _log_error(msg: str):
+    """Write an error message to stderr."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def scan_network_source_urls(
+        base_url: str,
+        systems: List[str] = None,
+        recursive: bool = True,
+        max_depth: int = 3,
+        auth_header: Optional[str] = None,
+        scan_workers: int = 16,
+        on_progress: Callable = None,
+        *,
+        _indent: str = "",
+        _url_sizes: Dict[str, int] = None,
+) -> Tuple[Dict[str, List[str]], Dict[str, int]]:
+    """Scan a network source and collect ROM URLs (without downloading).
+
+    Returns tuple of (dict of system -> list of URLs, dict of URL -> size).
+    """
+    sysdata = load_system_data()
+    detected: Dict[str, List[str]] = defaultdict(list)
+    if _url_sizes is None:
+        _url_sizes = {}
+
+    if not _indent:
+        _log(f"Scanning network source: {format_url(base_url)}", on_progress)
+
+    # Fetch root listing
+    try:
+        if not _indent:
+            print("  Fetching directory listing...", end='', flush=True)
+        content, final_url = fetch_url(base_url, auth_header=auth_header)
+        html = content.decode('utf-8', errors='replace')
+        base_url = final_url
+        if not _indent:
+            print(f" OK ({format_size(len(content))})")
+    except Exception as exc:  # pylint: disable=broad-except
+        if not _indent:
+            print()
+        _log_error(f"Error fetching {format_url(base_url)}: {exc}")
+        return dict(detected), _url_sizes
+
+    # Detect system from URL path
+    url_system = detect_system_from_path(base_url)
+
+    # Check for ROM files in this listing (with sizes)
+    rom_files_with_sizes = parse_html_for_files_with_sizes(html, base_url)
+    check_shutdown()
+
+    if rom_files_with_sizes:
+        total_size = sum(size for _, size in rom_files_with_sizes)
+        if not _indent:
+            size_info = f" ({format_size(total_size)})" if total_size > 0 else ""
+            _log(f"  Found {len(rom_files_with_sizes)} ROM files in root{size_info}",
+                 on_progress)
+
+        ambiguous_extensions = {'.chd', '.iso', '.bin', '.cue', '.img'}
+        for rom_url, size in rom_files_with_sizes:
+            url_clean = rom_url.split('?')[0].split('#')[0]
+            ext = ('.' + url_clean.rsplit('.', 1)[-1].lower()) if '.' in url_clean else ''
+            system = sysdata.extension_to_system.get(ext)
+            if ext in ambiguous_extensions and url_system:
+                system = url_system
+            elif not system and url_system:
+                system = url_system
+            elif not system:
+                system = 'unknown'
+            if systems is None or system in systems:
+                detected[system].append(rom_url)
+                if size > 0:
+                    _url_sizes[rom_url] = size
+
+    # Explore subdirectories
+    should_recurse = (recursive and max_depth > 0) or (
+        url_system and not rom_files_with_sizes and max_depth > 0)
+    if should_recurse:
+        subdirs = parse_html_for_directories(html, base_url)
+        if not _indent and subdirs:
+            print(f"  Parsing {len(subdirs)} entries...", end='', flush=True)
+
+        system_subdirs: list = []
+        other_subdirs: list = []
+
+        for subdir_url in subdirs:
+            folder_name = urllib.request.unquote(subdir_url.rstrip('/').split('/')[-1])
+            folder_lower = folder_name.lower()
+            system = sysdata.folder_aliases.get(folder_lower, folder_lower)
+            is_system_folder = system in sysdata.known_systems
+
+            if is_system_folder:
+                if systems and system not in systems:
+                    continue
+                system_subdirs.append((subdir_url, system, folder_name))
+            elif max_depth > 1 and not rom_files_with_sizes:
+                other_subdirs.append((subdir_url, folder_name))
+
+        # Parallel fetch system subdirectories
+        if system_subdirs:
+            urls_to_fetch = [u for u, _, _ in system_subdirs]
+            url_to_info = {u: (s, fn) for u, s, fn in system_subdirs}
+
+            if len(urls_to_fetch) > 1:
+                progress = ScanProgressBar(
+                    total=len(urls_to_fetch),
+                    desc=f"Scanning {len(urls_to_fetch)} system folders",
+                    indent=f"{_indent}  "
+                )
+                fetched = fetch_urls_parallel(
+                    urls_to_fetch,
+                    max_workers=scan_workers,
+                    auth_header=auth_header,
+                    progress_callback=progress.make_callback()
+                )
+                progress.finish()
+            else:
+                fetched = {}
+                for fetch_target in urls_to_fetch:
+                    try:
+                        cnt, final = fetch_url(fetch_target, auth_header=auth_header)
+                        fetched[fetch_target] = (cnt, final)
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+
+            for subdir_url in urls_to_fetch:
+                check_shutdown()
+                if subdir_url not in fetched:
+                    continue
+
+                system, folder_name = url_to_info[subdir_url]
+                sub_content, sub_final_url = fetched[subdir_url]
+                subdir_html = sub_content.decode('utf-8', errors='replace')
+                sub_files_with_sizes = parse_html_for_files_with_sizes(subdir_html, sub_final_url)
+
+                if sub_files_with_sizes:
+                    sub_rom_urls = [u for u, _ in sub_files_with_sizes]
+                    total_size = sum(s for _, s in sub_files_with_sizes)
+                    size_info = f" ({format_size(total_size)})" if total_size > 0 else ""
+                    _log(f"{_indent}    {folder_name} ({system}): "
+                         f"{len(sub_rom_urls)} ROM URLs{size_info}",
+                         on_progress)
+                    detected[system].extend(sub_rom_urls)
+                    for rom_url, size in sub_files_with_sizes:
+                        if size > 0:
+                            _url_sizes[rom_url] = size
+
+                # Nested subdirectories (region folders, etc.)
+                if max_depth > 1:
+                    nested_subdirs = parse_html_for_directories(subdir_html, sub_final_url)
+                    if nested_subdirs:
+                        nested_fetched = fetch_urls_parallel(
+                            nested_subdirs,
+                            max_workers=scan_workers,
+                            auth_header=auth_header
+                        )
+                        for nested_url, (nested_content, nested_final) in nested_fetched.items():
+                            check_shutdown()
+                            nested_html = nested_content.decode('utf-8', errors='replace')
+                            nested_files = parse_html_for_files_with_sizes(
+                                nested_html, nested_final)
+                            if nested_files:
+                                nested_name = urllib.request.unquote(
+                                    nested_url.rstrip('/').split('/')[-1])
+                                nested_roms = [u for u, _ in nested_files]
+                                nested_size = sum(s for _, s in nested_files)
+                                size_info = (f" ({format_size(nested_size)})"
+                                             if nested_size > 0 else "")
+                                _log(f"{_indent}      Found {len(nested_roms)} "
+                                     f"ROM URLs in {nested_name}{size_info}",
+                                     on_progress)
+                                detected[system].extend(nested_roms)
+                                for rom_url, size in nested_files:
+                                    if size > 0:
+                                        _url_sizes[rom_url] = size
+
+        if not _indent and subdirs:
+            total_found = len(system_subdirs) + len(other_subdirs)
+            parts = []
+            if system_subdirs:
+                parts.append(f"{len(system_subdirs)} system folders")
+            if other_subdirs:
+                parts.append(f"{len(other_subdirs)} game folders")
+            print(f" {total_found} found ({', '.join(parts)})" if parts else " 0 found")
+
+        if not _indent and not system_subdirs and not other_subdirs and not rom_files_with_sizes:
+            _log("  No ROM files or subdirectories found", on_progress)
+
+        # Non-system subdirectories
+        if other_subdirs:
+            if url_system and (systems is None or url_system in systems):
+                urls_to_fetch = [u for u, _ in other_subdirs]
+
+                if len(urls_to_fetch) > 3:
+                    progress = ScanProgressBar(
+                        total=len(urls_to_fetch),
+                        desc=f"Scanning {len(urls_to_fetch)} game folders",
+                        indent=f"{_indent}  "
+                    )
+                    fetched = fetch_urls_parallel(
+                        urls_to_fetch,
+                        max_workers=scan_workers,
+                        auth_header=auth_header,
+                        progress_callback=progress.make_callback()
+                    )
+                    progress.finish(
+                        f"Scanned {len(fetched)}/{len(urls_to_fetch)} folders")
+                else:
+                    fetched = {}
+                    for fetch_target in urls_to_fetch:
+                        try:
+                            cnt, final = fetch_url(fetch_target, auth_header=auth_header)
+                            fetched[fetch_target] = (cnt, final)
+                        except Exception:  # pylint: disable=broad-except
+                            pass
+
+                total_roms = 0
+                total_size = 0
+                nested_urls_to_fetch: list = []
+                for subdir_url, (sub_content, sub_final_url) in fetched.items():
+                    check_shutdown()
+                    subdir_html = sub_content.decode('utf-8', errors='replace')
+                    sub_files = parse_html_for_files_with_sizes(subdir_html, sub_final_url)
+                    if sub_files:
+                        for rom_url, size in sub_files:
+                            detected[url_system].append(rom_url)
+                            if size > 0:
+                                _url_sizes[rom_url] = size
+                                total_size += size
+                        total_roms += len(sub_files)
+                    nested_dirs = parse_html_for_directories(subdir_html, sub_final_url)
+                    if nested_dirs:
+                        nested_urls_to_fetch.extend(nested_dirs)
+
+                if nested_urls_to_fetch:
+                    if len(nested_urls_to_fetch) > 3:
+                        nested_progress = ScanProgressBar(
+                            total=len(nested_urls_to_fetch),
+                            desc=f"Scanning {len(nested_urls_to_fetch)} nested folders",
+                            indent=f"{_indent}  "
+                        )
+                        nested_fetched = fetch_urls_parallel(
+                            nested_urls_to_fetch,
+                            max_workers=scan_workers,
+                            auth_header=auth_header,
+                            progress_callback=nested_progress.make_callback()
+                        )
+                        nested_progress.finish(
+                            f"Scanned {len(nested_fetched)}/"
+                            f"{len(nested_urls_to_fetch)} nested folders"
+                        )
+                    else:
+                        nested_fetched = {}
+                        for nurl in nested_urls_to_fetch:
+                            try:
+                                ncontent, nfinal = fetch_url(nurl, auth_header=auth_header)
+                                nested_fetched[nurl] = (ncontent, nfinal)
+                            except Exception:  # pylint: disable=broad-except
+                                pass
+
+                    for _nested_url, (ncontent, nfinal_url) in nested_fetched.items():
+                        check_shutdown()
+                        nested_html = ncontent.decode('utf-8', errors='replace')
+                        nested_files = parse_html_for_files_with_sizes(
+                            nested_html, nfinal_url)
+                        if nested_files:
+                            for rom_url, size in nested_files:
+                                detected[url_system].append(rom_url)
+                                if size > 0:
+                                    _url_sizes[rom_url] = size
+                                    total_size += size
+                            total_roms += len(nested_files)
+
+                if total_roms > 0:
+                    size_info = f" ({format_size(total_size)})" if total_size > 0 else ""
+                    _log(f"{_indent}  Found {total_roms} ROM URLs{size_info}",
+                         on_progress)
+
+            else:
+                # No URL system detected — scan recursively (sequentially)
+                for subdir_url, folder_name in other_subdirs:
+                    check_shutdown()
+                    _log(f"{_indent}  Scanning subfolder: {folder_name}...",
+                         on_progress)
+                    sub_detected, _ = scan_network_source_urls(
+                        subdir_url, systems,
+                        recursive=True, max_depth=max_depth - 1,
+                        auth_header=auth_header,
+                        scan_workers=scan_workers,
+                        on_progress=on_progress,
+                        _indent=_indent + "  ",
+                        _url_sizes=_url_sizes,
+                    )
+                    for sys_code, url_list in sub_detected.items():
+                        detected[sys_code].extend(url_list)
+
+    return dict(detected), _url_sizes
+
+
+# ---------------------------------------------------------------------------
+# High-level scan_network_source (public API)
+# ---------------------------------------------------------------------------
+
+def scan_network_source(url: str, systems: List[str] = None,
+                        recursive: bool = True, max_depth: int = 3,
+                        auth_header: str = None, scan_workers: int = 16,
+                        cache_dir: Path = None, no_cache: bool = False,
+                        on_progress: Callable = None) -> ScanResult:
+    """Scan a network source for ROM URLs.
+
+    Returns structured ScanResult instead of printing to stdout.
+    Uses scan cache if available and fresh.
+
+    Args:
+        url: Base URL to scan.
+        systems: Optional list of system codes to filter for.
+        recursive: Whether to follow subdirectories.
+        max_depth: Maximum directory traversal depth.
+        auth_header: Optional HTTP auth header value.
+        scan_workers: Number of concurrent scan workers.
+        cache_dir: Directory for scan cache files.
+        no_cache: If True, bypass scan cache.
+        on_progress: Optional callback for progress updates.
+    """
+    # Check cache first
+    if cache_dir and not no_cache:
+        cached = load_scan_cache(cache_dir, url)
+        if cached:
+            url_dict, url_sizes = cached
+            if on_progress:
+                total = sum(len(urls) for urls in url_dict.values())
+                on_progress(ProgressEvent(
+                    phase="complete",
+                    message=f"Using cached scan ({total} URLs)"
+                ))
+            return ScanResult(url_dict=url_dict, url_sizes=url_sizes)
+
+    # Full scan
+    url_dict, url_sizes = scan_network_source_urls(
+        url, systems,
+        recursive=recursive,
+        max_depth=max_depth,
+        auth_header=auth_header,
+        scan_workers=scan_workers,
+        on_progress=on_progress,
+    )
+
+    # Save to cache
+    if cache_dir and not no_cache:
+        save_scan_cache(cache_dir, url, dict(url_dict), url_sizes)
+
+    return ScanResult(url_dict=dict(url_dict), url_sizes=url_sizes)
+
+
+# ---------------------------------------------------------------------------
+# Local source scanning (delegates to monolith — not extracted yet)
+# ---------------------------------------------------------------------------
 
 def scan_local_sources(source_paths: List[Path],
                        recursive: bool = False, max_depth: int = 3,
@@ -32,15 +526,15 @@ def scan_local_sources(source_paths: List[Path],
     from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
     mod = get_module()
 
-    all_systems = {}
+    all_systems: Dict[str, list] = {}
     for source_path in source_paths:
-        detected = mod.scan_for_systems(
+        local_detected = mod.scan_for_systems(
             str(source_path),
             recursive=recursive,
             max_depth=max_depth,
             verbose=verbose
         )
-        for system, files in detected.items():
+        for system, files in local_detected.items():
             if system in all_systems:
                 all_systems[system].extend(files)
             else:


### PR DESCRIPTION
## Summary

Extract all network and scanning code from the monolith into standalone v2 modules. ~1,150 lines of real implementation replacing _monolith delegation.

- **network.py**: URL utils, HTML scraping, fetch_url, fetch_urls_parallel, validation, scan cache, shutdown mechanism
- **scanner.py**: ScanProgressBar, detect_system_from_path, scan_network_source_urls with progress callbacks

### What changed
- `network.py` no longer imports from `_monolith.py` — fully standalone
- `scanner.py` only uses `_monolith` for `scan_local_sources` (local scanning not yet extracted)
- `cli.py` updated to import from extracted modules instead of duplicating code

## Test plan
- [ ] `python tests/test_v2_modules.py` — 46/46 pass
- [ ] `python tests/test_selection.py` — 300/300 pass (no regressions)
- [ ] `python -m pylint retro_refiner/network.py retro_refiner/scanner.py` — 10.00/10