### PR TITLE
feat(v2): extract filtering engine from monolith

### DIFF
--- a/retro_refiner/dat.py
+++ b/retro_refiner/dat.py
@@ -1,45 +1,131 @@
-"""DAT file operations: loading, parsing, CRC verification."""
+"""DAT file operations: loading, parsing, CRC verification, title normalization.
+
+Standalone implementations extracted from the monolith.  Console output is
+replaced by plain stderr for errors; verbose callbacks come from callers.
+"""
+import binascii
+import io
+import json
+import re
+import shutil
+import sys
+import threading
+import time
+import unicodedata
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, List, Optional
+
+from retro_refiner.paths import get_base_path
+from retro_refiner.systems import load_system_data
 
 
-def load_dat_entries(system: str, dat_dir: Path) -> Dict[str, object]:
-    """Load DAT entries for a system.
+# =============================================================================
+# Dataclasses
+# =============================================================================
 
-    Returns dict of ROM name -> DatRomEntry from the monolith.
+@dataclass
+class RomInfo:
+    """Parsed ROM metadata from a filename."""
+    filename: str
+    base_title: str
+    region: str
+    revision: int
+    is_english: bool
+    is_translation: bool
+    is_beta: bool
+    is_demo: bool
+    is_promo: bool
+    is_sample: bool
+    is_proto: bool
+    is_bios: bool
+    is_pirate: bool
+    is_unlicensed: bool
+    is_homebrew: bool
+    is_rerelease: bool
+    is_compilation: bool
+    is_lock_on: bool
+    has_hacks: bool = False
+    year: int = 0
+    disc_number: int = 0
 
-    Args:
-        system: System code (e.g. 'snes', 'genesis').
-        dat_dir: Directory containing DAT files.
+
+@dataclass
+class DatRomEntry:
+    """ROM entry from a DAT file."""
+    name: str
+    rom_name: str
+    size: int
+    crc: str
+    md5: str
+    sha1: str
+    region: str
+    is_parent: bool
+    parent_name: str
+
+
+# =============================================================================
+# Title Mappings
+# =============================================================================
+
+_title_mappings_cache: Optional[Dict[str, str]] = None
+
+
+def load_title_mappings() -> Dict[str, str]:
+    """Load title mappings from data/title_mappings.json.
+
+    Returns a flat dict of {source_title: target_title}.
+    Caches the result for subsequent calls.
     """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().load_all_system_dats(system, dat_dir)
+    global _title_mappings_cache  # pylint: disable=global-statement
+
+    if _title_mappings_cache is not None:
+        return _title_mappings_cache
+
+    mappings_path = get_base_path() / 'data' / 'title_mappings.json'
+    flat_mappings = {}
+
+    if mappings_path.exists():
+        try:
+            with open(mappings_path, 'r', encoding='utf-8') as fh:
+                data = json.load(fh)
+            for category, entries in data.items():
+                if category.startswith('_'):
+                    continue
+                if isinstance(entries, dict):
+                    flat_mappings.update(entries)
+        except (json.JSONDecodeError, IOError) as exc:
+            print(f"WARNING: Could not load title_mappings.json: {exc}",
+                  file=sys.stderr)
+
+    _title_mappings_cache = flat_mappings
+    return flat_mappings
 
 
-def download_dat(system: str, dat_dir: Path,
-                 on_progress: Callable = None) -> Optional[Path]:
-    """Download DAT file for a system.
-
-    Returns the path to the downloaded file, or None on failure.
-
-    Args:
-        system: System code.
-        dat_dir: Directory to store downloaded DATs.
-        on_progress: Optional progress callback.
-    """
-    _ = on_progress  # Reserved for future progress reporting
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().download_libretro_dat(system, dat_dir)
+def reset_title_mappings_cache() -> None:
+    """Clear the title mappings cache (used in tests)."""
+    global _title_mappings_cache  # pylint: disable=global-statement
+    _title_mappings_cache = None
 
 
-def parse_rom_filename(filename: str) -> object:
-    """Parse a ROM filename into a RomInfo object.
+# =============================================================================
+# Title Normalization
+# =============================================================================
 
-    The returned object has fields like title, region, languages,
-    revision, is_beta, is_proto, etc.
-    """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().parse_rom_filename(filename)
+# Pre-compiled patterns used in normalize_title()
+_RE_ARTICLE_COMMA = re.compile(r',\s*(the|a|an)\s*')
+_RE_ARTICLE_START = re.compile(r'^(the|a|an)\s+')
+_RE_PUNCTUATION = re.compile(r'[:\-\'.,]')
+_RE_WHITESPACE_NORM = re.compile(r'\s+')
+_RE_ROMAN_NUMERALS = [
+    (re.compile(r'\bviii\b'), '8'), (re.compile(r'\bvii\b'), '7'),
+    (re.compile(r'\bvi\b'), '6'), (re.compile(r'\biv\b'), '4'),
+    (re.compile(r'\bv\b'), '5'), (re.compile(r'\biii\b'), '3'),
+    (re.compile(r'\bii\b'), '2'), (re.compile(r'\bi\b'), '1'),
+]
 
 
 def normalize_title(title: str) -> str:
@@ -48,5 +134,629 @@ def normalize_title(title: str) -> str:
     Lowercases, strips punctuation, converts Roman numerals to Arabic,
     and applies title mappings from data/title_mappings.json.
     """
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().normalize_title(title)
+    normalized = title.lower()
+
+    # Strip accented characters to ASCII equivalents
+    normalized = unicodedata.normalize('NFKD', normalized)
+    normalized = ''.join(c for c in normalized if not unicodedata.combining(c))
+
+    # Handle "Title, The" pattern
+    normalized = _RE_ARTICLE_COMMA.sub(' ', normalized)
+    normalized = _RE_ARTICLE_START.sub('', normalized)
+
+    # Normalize punctuation
+    normalized = _RE_PUNCTUATION.sub(' ', normalized)
+    normalized = _RE_WHITESPACE_NORM.sub(' ', normalized)
+    normalized = normalized.strip()
+
+    # Normalize roman numerals to arabic
+    for pattern, replacement in _RE_ROMAN_NUMERALS:
+        normalized = pattern.sub(replacement, normalized)
+
+    # Apply title mappings
+    title_mappings = load_title_mappings()
+    for variant, canonical in title_mappings.items():
+        if normalized == variant:
+            normalized = canonical
+
+    return normalized
+
+
+def normalize_title_for_dedupe(title: str) -> str:
+    """Normalize a title for cross-platform dedupe (preserves leading articles).
+
+    Same as normalize_title() but skips article stripping to avoid false
+    positives like 'The Bully' (DOS) colliding with 'Bully' (PS2).
+    """
+    normalized = title.lower()
+    normalized = unicodedata.normalize('NFKD', normalized)
+    normalized = ''.join(c for c in normalized if not unicodedata.combining(c))
+    # Skip _RE_ARTICLE_COMMA and _RE_ARTICLE_START
+    normalized = _RE_PUNCTUATION.sub(' ', normalized)
+    normalized = _RE_WHITESPACE_NORM.sub(' ', normalized)
+    normalized = normalized.strip()
+    for pattern, replacement in _RE_ROMAN_NUMERALS:
+        normalized = pattern.sub(replacement, normalized)
+    title_mappings = load_title_mappings()
+    for variant, canonical in title_mappings.items():
+        if normalized == variant:
+            normalized = canonical
+    return normalized
+
+
+# =============================================================================
+# DAT URL construction
+# =============================================================================
+
+# Base URLs for DATs in libretro-database
+LIBRETRO_DB_NOINTRO_URL = (
+    "https://raw.githubusercontent.com/libretro/"
+    "libretro-database/master/metadat/no-intro"
+)
+LIBRETRO_DB_DAT_URL = (
+    "https://raw.githubusercontent.com/libretro/"
+    "libretro-database/master/dat"
+)
+LIBRETRO_DB_REDUMP_URL = (
+    "https://raw.githubusercontent.com/libretro/"
+    "libretro-database/master/metadat/redump"
+)
+
+# Base URL for T-En DAT files
+TEN_DAT_BASE_URL = "https://archive.org/download/En-ROMs/DATs/"
+
+
+def get_libretro_dat_url(system: str) -> list:
+    """Get possible libretro DAT URLs for a system (returns list to try).
+
+    For disc-based systems (in REDUMP_DAT_SYSTEMS), tries the Redump URL
+    first since the dat/ folder may contain a stub file instead of the full
+    DAT.
+    """
+    sdata = load_system_data()
+    dat_name = sdata.libretro_dat_systems.get(system)
+    if not dat_name:
+        return []
+
+    encoded_name = urllib.request.quote(dat_name)
+
+    if system in sdata.redump_dat_systems:
+        return [
+            f"{LIBRETRO_DB_REDUMP_URL}/{encoded_name}.dat",
+            f"{LIBRETRO_DB_DAT_URL}/{encoded_name}.dat",
+            f"{LIBRETRO_DB_NOINTRO_URL}/{encoded_name}.dat",
+        ]
+
+    return [
+        f"{LIBRETRO_DB_NOINTRO_URL}/{encoded_name}.dat",
+        f"{LIBRETRO_DB_DAT_URL}/{encoded_name}.dat",
+        f"{LIBRETRO_DB_REDUMP_URL}/{encoded_name}.dat",
+    ]
+
+
+# =============================================================================
+# DAT Download Functions
+# =============================================================================
+
+def download_libretro_dat(system: str, dest_dir: Path,
+                          force: bool = False,
+                          on_progress: Callable = None) -> Optional[Path]:
+    """Download libretro DAT file for a system.
+
+    Returns the path to the downloaded file, or None on failure.
+    """
+    _ = on_progress  # Reserved for future progress reporting
+    urls = get_libretro_dat_url(system)
+    if not urls:
+        print(f"ERROR: No DAT mapping for: {system}", file=sys.stderr)
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dat_path = dest_dir / f"{system}.dat"
+
+    if dat_path.exists() and not force:
+        return dat_path
+
+    if dat_path.exists() and force:
+        dat_path.unlink()
+
+    for url in urls:
+        try:
+            req = urllib.request.Request(
+                url, headers={'User-Agent': 'Retro-Refiner/1.0'})
+            with urllib.request.urlopen(req, timeout=30) as response:
+                with open(dat_path, 'wb') as fh:
+                    shutil.copyfileobj(response, fh)
+            return dat_path
+        except urllib.error.HTTPError:
+            continue
+        except Exception:  # pylint: disable=broad-except
+            continue
+
+    print(f"ERROR: Failed to download DAT for: {system}", file=sys.stderr)
+    return None
+
+
+def download_additional_dats(system: str, dest_dir: Path,
+                             force: bool = False) -> List[Path]:
+    """Download additional DAT files for a system (digital/PSN variants)."""
+    sdata = load_system_data()
+    additional_names = sdata.additional_dat_systems.get(system, [])
+    if not additional_names:
+        return []
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    downloaded = []
+
+    for i, dat_name in enumerate(additional_names, 1):
+        dat_path = dest_dir / f"{system}_extra{i}.dat"
+        if dat_path.exists() and not force:
+            downloaded.append(dat_path)
+            continue
+
+        if dat_path.exists() and force:
+            dat_path.unlink()
+
+        encoded = urllib.request.quote(dat_name)
+        urls = [
+            f"{LIBRETRO_DB_NOINTRO_URL}/{encoded}.dat",
+            f"{LIBRETRO_DB_DAT_URL}/{encoded}.dat",
+        ]
+        for url in urls:
+            try:
+                req = urllib.request.Request(
+                    url, headers={'User-Agent': 'Retro-Refiner/1.0'})
+                with urllib.request.urlopen(req, timeout=30) as response:
+                    with open(dat_path, 'wb') as fh:
+                        shutil.copyfileobj(response, fh)
+                downloaded.append(dat_path)
+                break
+            except Exception:  # pylint: disable=broad-except
+                continue
+
+    return downloaded
+
+
+# =============================================================================
+# T-En DAT support
+# =============================================================================
+
+def is_ten_source(url: str) -> bool:
+    """Check if a URL is a T-En (translation) collection source."""
+    url_decoded = urllib.request.unquote(url).lower()
+    return '[t-en]' in url_decoded or 't-en collection' in url_decoded
+
+
+def fetch_ten_dat_listing() -> Dict[str, str]:
+    """Fetch the T-En DAT directory listing from Archive.org.
+
+    Returns a dict mapping system prefix to ZIP filename.
+    """
+    try:
+        req = urllib.request.Request(
+            TEN_DAT_BASE_URL,
+            headers={'User-Agent': 'Retro-Refiner/1.0'})
+        with urllib.request.urlopen(req, timeout=30) as response:
+            html = response.read().decode('utf-8', errors='ignore')
+
+        zip_files = {}
+
+        for match in re.finditer(r'href="([^"]+\.zip)"', html):
+            href = urllib.request.unquote(match.group(1))
+            if '[T-En] Collection' in href:
+                prefix = href.split(' [T-En] Collection')[0]
+                zip_files[prefix] = href
+
+        for match in re.finditer(r'<td>([^<]+\.zip)</td>', html):
+            filename = match.group(1)
+            if '[T-En] Collection' in filename:
+                prefix = filename.split(' [T-En] Collection')[0]
+                if prefix not in zip_files:
+                    zip_files[prefix] = filename
+
+        return zip_files
+    except Exception:  # pylint: disable=broad-except
+        return {}
+
+
+def download_ten_dat(system: str, dest_dir: Path, force: bool = False,
+                     auth_header: Optional[str] = None,
+                     listing_cache: Optional[Dict[str, str]] = None
+                     ) -> Optional[Path]:
+    """Download T-En DAT file for a system from Archive.org.
+
+    T-En DATs are ZIP files containing a DAT file inside.
+    Requires Archive.org authentication (auth_header).
+    """
+    sdata = load_system_data()
+    dat_prefix = sdata.ten_dat_systems.get(system)
+    if not dat_prefix:
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dat_path = dest_dir / f"{system}_t-en.dat"
+
+    if dat_path.exists() and not force:
+        return dat_path
+
+    if listing_cache is not None:
+        zip_filename = listing_cache.get(dat_prefix)
+    else:
+        listing = fetch_ten_dat_listing()
+        zip_filename = listing.get(dat_prefix)
+
+    if not zip_filename:
+        return None
+
+    zip_url = (TEN_DAT_BASE_URL
+               + urllib.request.quote(zip_filename, safe='[]()-'))
+
+    headers = {'User-Agent': 'Retro-Refiner/1.0'}
+    if auth_header:
+        headers['Authorization'] = auth_header
+
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            req = urllib.request.Request(zip_url, headers=headers)
+            with urllib.request.urlopen(req, timeout=60) as response:
+                zip_data = response.read()
+
+            with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+                dat_files = [n for n in zf.namelist()
+                             if n.lower().endswith('.dat')]
+                if not dat_files:
+                    return None
+
+                with zf.open(dat_files[0]) as src:
+                    with open(dat_path, 'wb') as dst:
+                        shutil.copyfileobj(src, dst)
+
+            return dat_path
+
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            if attempt < max_retries - 1:
+                time.sleep((attempt + 1) * 2)
+            else:
+                return None
+        except Exception:  # pylint: disable=broad-except
+            if attempt < max_retries - 1:
+                time.sleep((attempt + 1) * 2)
+            else:
+                return None
+
+    return None
+
+
+# =============================================================================
+# DAT Parsing
+# =============================================================================
+
+def detect_dat_region(name: str) -> str:
+    """Detect region from DAT game name."""
+    name_lower = name.lower()
+    if '(usa)' in name_lower or '(us)' in name_lower:
+        return 'USA'
+    if '(world)' in name_lower:
+        return 'World'
+    if '(europe)' in name_lower or '(eu)' in name_lower:
+        return 'Europe'
+    if '(japan)' in name_lower or '(jp)' in name_lower:
+        return 'Japan'
+    if '(australia)' in name_lower or '(au)' in name_lower:
+        return 'Australia'
+    if '(asia)' in name_lower:
+        return 'Asia'
+    if '(korea)' in name_lower:
+        return 'Korea'
+    return 'Unknown'
+
+
+def parse_dat_file(dat_path: Path) -> Dict[str, DatRomEntry]:
+    """Parse a DAT file (auto-detects ClrMamePro text or Logiqx XML)."""
+    with open(dat_path, 'r', encoding='utf-8-sig', errors='ignore') as fh:
+        first_line = fh.readline().strip()
+
+    if first_line.startswith('<?xml') or first_line.startswith('<'):
+        return parse_logiqx_xml_dat(dat_path)
+    return parse_clrmamepro_dat(dat_path)
+
+
+def parse_logiqx_xml_dat(dat_path: Path) -> Dict[str, DatRomEntry]:
+    """Parse a Logiqx XML format DAT file."""
+    entries = {}
+
+    with open(dat_path, 'r', encoding='utf-8-sig', errors='ignore') as fh:
+        content = fh.read()
+
+    for machine_match in re.finditer(
+            r'<(?:machine|game)\s+name="([^"]+)"[^>]*>'
+            r'(.*?)</(?:machine|game)>', content, re.DOTALL):
+        game_name = machine_match.group(1)
+        machine_content = machine_match.group(2)
+
+        for rom_match in re.finditer(r'<rom\s+([^>]+)/>', machine_content):
+            rom_attrs = rom_match.group(1)
+
+            name_match = re.search(r'name="([^"]+)"', rom_attrs)
+            size_match = re.search(r'size="(\d+)"', rom_attrs)
+            crc_match = re.search(r'crc="([a-fA-F0-9]+)"', rom_attrs)
+            md5_match = re.search(r'md5="([a-fA-F0-9]+)"', rom_attrs)
+            sha1_match = re.search(r'sha1="([a-fA-F0-9]+)"', rom_attrs)
+
+            if name_match and crc_match:
+                rom_name = name_match.group(1)
+                crc = crc_match.group(1).lower()
+                region = detect_dat_region(game_name)
+
+                entry = DatRomEntry(
+                    name=game_name,
+                    rom_name=rom_name,
+                    size=int(size_match.group(1)) if size_match else 0,
+                    crc=crc,
+                    md5=md5_match.group(1).lower() if md5_match else '',
+                    sha1=sha1_match.group(1).lower() if sha1_match else '',
+                    region=region,
+                    is_parent=True,
+                    parent_name='',
+                )
+                entries[crc] = entry
+
+    return entries
+
+
+def parse_clrmamepro_dat(dat_path: Path) -> Dict[str, DatRomEntry]:
+    """Parse a ClrMamePro format DAT file."""
+    entries = {}
+
+    with open(dat_path, 'r', encoding='utf-8', errors='ignore') as fh:
+        content = fh.read()
+
+    in_game = False
+    current_game = None
+    brace_count = 0
+
+    lines = content.split('\n')
+    for line in lines:
+        line = line.strip()
+
+        if line.startswith('game') and '(' in line:
+            in_game = True
+            brace_count = line.count('(') - line.count(')')
+            name_match = re.search(r'name\s+"([^"]+)"', line)
+            if name_match:
+                current_game = name_match.group(1)
+        elif in_game:
+            brace_count += line.count('(') - line.count(')')
+
+            if 'rom' in line and 'name' in line:
+                rom_match = re.search(r'name\s+"([^"]+)"', line)
+                size_match = re.search(r'size\s+(\d+)', line)
+                crc_match = re.search(r'crc\s+([a-fA-F0-9]+)', line)
+                md5_match = re.search(r'md5\s+([a-fA-F0-9]+)', line)
+                sha1_match = re.search(r'sha1\s+([a-fA-F0-9]+)', line)
+
+                if rom_match and crc_match:
+                    rom_name = rom_match.group(1)
+                    crc = crc_match.group(1).lower()
+                    region = (detect_dat_region(current_game)
+                              if current_game else 'Unknown')
+
+                    entry = DatRomEntry(
+                        name=current_game or rom_name,
+                        rom_name=rom_name,
+                        size=int(size_match.group(1)) if size_match else 0,
+                        crc=crc,
+                        md5=(md5_match.group(1).lower()
+                             if md5_match else ''),
+                        sha1=(sha1_match.group(1).lower()
+                              if sha1_match else ''),
+                        region=region,
+                        is_parent=True,
+                        parent_name='',
+                    )
+                    entries[crc] = entry
+
+            if brace_count <= 0:
+                in_game = False
+                current_game = None
+
+    return entries
+
+
+# =============================================================================
+# DAT Loading
+# =============================================================================
+
+def load_all_system_dats(system: str,
+                         dat_dir: Path) -> Dict[str, DatRomEntry]:
+    """Load primary + additional DAT files for a system and merge entries."""
+    all_entries: Dict[str, DatRomEntry] = {}
+    dat_path = dat_dir / f"{system}.dat"
+    if dat_path.exists():
+        all_entries.update(parse_dat_file(dat_path))
+
+    for extra in sorted(dat_dir.glob(f"{system}_extra*.dat")):
+        try:
+            entries = parse_dat_file(extra)
+            all_entries.update(entries)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    return all_entries
+
+
+# =============================================================================
+# CRC Verification
+# =============================================================================
+
+def calculate_crc32(filepath: Path) -> str:
+    """Calculate CRC32 checksum of a file."""
+    crc = 0
+    with open(filepath, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(65536), b''):
+            crc = binascii.crc32(chunk, crc)
+    return format(crc & 0xFFFFFFFF, '08x')
+
+
+def calculate_crc32_from_zip(zip_path: Path) -> Optional[str]:
+    """Calculate CRC32 of the first file inside a ZIP."""
+    try:
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for name in zf.namelist():
+                if not name.endswith('/'):
+                    with zf.open(name) as fh:
+                        crc = 0
+                        # pylint: disable=cell-var-from-loop
+                        for chunk in iter(lambda: fh.read(65536), b''):
+                            crc = binascii.crc32(chunk, crc)
+                        return format(crc & 0xFFFFFFFF, '08x')
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return None
+
+
+def load_crc_cache(cache_path: Path) -> dict:
+    """Load CRC cache from JSON.
+
+    Returns {filepath_str: {"crc": ..., "mtime": ..., "size": ...}}.
+    """
+    if cache_path.exists():
+        try:
+            with open(cache_path, 'r', encoding='utf-8') as fh:
+                return json.load(fh)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def save_crc_cache(cache_path: Path, cache: dict):
+    """Save CRC cache to JSON."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(cache_path, 'w', encoding='utf-8') as fh:
+            json.dump(cache, fh)
+    except IOError:
+        pass
+
+
+def get_cached_crc(filepath: Path, crc_cache: dict,
+                   download_crc_index: dict = None) -> Optional[str]:
+    """Get CRC from cache or calculate and cache it.
+
+    Uses mtime+size to invalidate.
+    """
+    key = str(filepath)
+    stat = filepath.stat()
+    mtime = stat.st_mtime
+    size = stat.st_size
+
+    cached = crc_cache.get(key)
+    if cached and cached.get('mtime') == mtime and cached.get('size') == size:
+        return cached['crc']
+
+    if download_crc_index:
+        indexed = download_crc_index.get(key)
+        if (indexed and indexed.get('mtime') == mtime
+                and indexed.get('size') == size):
+            crc = indexed['crc']
+            crc_cache[key] = {'crc': crc, 'mtime': mtime, 'size': size}
+            return crc
+
+    if filepath.suffix.lower() == '.zip':
+        crc = calculate_crc32_from_zip(filepath)
+    else:
+        crc = calculate_crc32(filepath)
+
+    if crc:
+        crc_cache[key] = {'crc': crc, 'mtime': mtime, 'size': size}
+    return crc
+
+
+class BackgroundCrcIndexer:
+    """Compute CRC32 checksums in background threads as files finish downloading.
+
+    Receives file paths via submit() and computes CRCs in a thread pool,
+    so verification overlaps with ongoing downloads.
+    """
+
+    def __init__(self, cache_dir: Path, max_workers: int = 2):
+        self.cache_dir = cache_dir
+        self.index_path = cache_dir / '_crc_index.json'
+        self._lock = threading.Lock()
+        self._index: dict = {}
+        self._executor = _ThreadPoolExecutor(max_workers=max_workers)
+        self._futures: list = []
+        self._new_count = 0
+        self._cached_count = 0
+        self._submitted_count = 0
+
+        if self.index_path.exists():
+            try:
+                with open(self.index_path, 'r', encoding='utf-8') as fh:
+                    self._index = json.load(fh)
+            except (json.JSONDecodeError, IOError):
+                pass
+
+    @property
+    def verified_count(self) -> int:
+        """Number of files that have completed CRC verification."""
+        with self._lock:
+            return self._new_count + self._cached_count
+
+    def submit(self, filepath: Path) -> None:
+        """Queue a file for background CRC computation."""
+        future = self._executor.submit(self._compute_crc, filepath)
+        with self._lock:
+            self._futures.append(future)
+            self._submitted_count += 1
+
+    def _compute_crc(self, filepath: Path) -> None:
+        """Compute CRC for a single file and store in the index."""
+        if not filepath.exists():
+            return
+        try:
+            stat = filepath.stat()
+        except OSError:
+            return
+        mtime = stat.st_mtime
+        size = stat.st_size
+        key = str(filepath)
+
+        with self._lock:
+            existing = self._index.get(key)
+            if (existing and existing.get('mtime') == mtime
+                    and existing.get('size') == size):
+                self._cached_count += 1
+                return
+
+        if filepath.suffix.lower() == '.zip':
+            crc = calculate_crc32_from_zip(filepath)
+        else:
+            crc = calculate_crc32(filepath)
+
+        if crc:
+            with self._lock:
+                self._index[key] = {
+                    'crc': crc, 'mtime': mtime, 'size': size}
+                self._new_count += 1
+
+    def wait_and_save(self) -> dict:
+        """Wait for all pending CRC computations, save index, return it."""
+        self._executor.shutdown(wait=True)
+
+        try:
+            with open(self.index_path, 'w', encoding='utf-8') as fh:
+                json.dump(self._index, fh)
+        except IOError:
+            pass
+
+        return self._index
+
+
+# Lazy import to avoid pulling in concurrent.futures at module load
+def _ThreadPoolExecutor(**kwargs):  # pylint: disable=invalid-name
+    from concurrent.futures import ThreadPoolExecutor  # pylint: disable=import-outside-toplevel
+    return ThreadPoolExecutor(**kwargs)

--- a/retro_refiner/filter.py
+++ b/retro_refiner/filter.py
@@ -1,9 +1,451 @@
-"""ROM filtering: select best ROMs from a collection."""
-from typing import Callable, Dict, List
+"""ROM filtering: parsing filenames, selecting best ROMs from groups.
 
-from retro_refiner.config import Config
-from retro_refiner.models import FilterResult
+Standalone implementations extracted from the monolith.  Console output is
+replaced by optional ``on_progress`` callbacks and plain stderr for errors.
+"""
+import fnmatch
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
 
+from retro_refiner.config import Config, DEFAULT_REGION_PRIORITY
+from retro_refiner.dat import (
+    RomInfo,
+    normalize_title,
+)
+from retro_refiner.models import FilterResult, FilterStats
+from retro_refiner.network import get_filename_from_url
+
+
+# =============================================================================
+# Pre-compiled regex patterns used by parse_rom_filename()
+# =============================================================================
+
+_RE_EXTENSION = re.compile(
+    r'\.(zip|7z|rar|sfc|smc|nes|n64|z64|v64|md|gen|bin|gb|gbc|gba|nds|gcm'
+    r'|iso|cue|pce|col|a26|a52|a78|jag|lnx|st|int|gg|sms|sg|32x|vb|ws|wsc'
+    r'|rom|mx1|mx2)$', re.IGNORECASE)
+_RE_BETA = re.compile(r'\(Beta[^)]*\)')
+_RE_PROTO = re.compile(r'\(Proto[^)]*\)')
+_RE_MULTI_GAME = re.compile(r'\+ .+ \(')
+_RE_NUMBERING = re.compile(r'\b(\d) & (\d)\b')
+_RE_TRANSLATION = re.compile(r'\[T-En[^\]]*\]')
+_RE_REGION = re.compile(r'\(([^)]+)\)')
+_RE_ENGLISH_TAG = re.compile(r'\([^)]*\bEn\b[^)]*\)')
+_RE_REVISION = re.compile(r'\(Rev\s*([A-Z0-9]+)\)')
+_RE_VERSION = re.compile(r'\(v(\d+)\.(\d+)\)')
+_RE_TITLE_VERSION = re.compile(r'\s+v(\d+(?:\.\d+)?)\s*$', re.IGNORECASE)
+_RE_BRACKETS = re.compile(r'\[[^\]]+\]')
+_RE_PARENS = re.compile(r'\s*\([^)]+\)')
+_RE_WHITESPACE = re.compile(r'\s+')
+_RE_YEAR = re.compile(r'\((\d{4})\)')
+_RE_DISC = re.compile(
+    r'\((?:Disc|Disk|Part)\s+(\d+)(?:\s+of\s+\d+)?\)', re.IGNORECASE)
+
+# TOSEC naming convention patterns
+_RE_TOSEC_DATE = re.compile(
+    r'^\(\d{4}(?:-\d{2}(?:-\d{2})?)?\)$|^\(\d{2}xx\)$')
+_RE_TOSEC_REVISION = re.compile(r'\s+r(\d+)\s*$')
+_RE_TOSEC_BAD_FLAGS = re.compile(r'\[([bo!a]|cr[^\]]*)\]', re.IGNORECASE)
+_TOSEC_REGION_MAP = {
+    'US': 'USA', 'GB': 'Europe', 'EU': 'Europe', 'JP': 'Japan',
+    'FR': 'France', 'DE': 'Germany', 'ES': 'Spain', 'IT': 'Italy',
+    'AU': 'Australia', 'NL': 'Netherlands', 'SE': 'Sweden',
+    'BR': 'Brazil', 'KR': 'Korea', 'CN': 'China', 'TW': 'Taiwan',
+    'CA': 'Canada', 'PT': 'Portugal', 'NO': 'Norway', 'DK': 'Denmark',
+    'FI': 'Finland',
+}
+_TOSEC_ENGLISH_REGIONS = {'US', 'GB', 'AU', 'CA'}
+
+# =============================================================================
+# Filter pattern lists
+# =============================================================================
+
+RERELEASE_PATTERNS = [re.compile(p) for p in [
+    r'Virtual Console', r'GameCube\)', r'\(LodgeNet\)',
+    r'\(Arcade\)', r'Sega Channel', r'Switch Online',
+    r'Classic Mini', r'Retro-Bit', r'Evercade',
+    r'Wii Virtual Console', r'Mega Drive Mini',
+    r'Collection\)', r'\(NP\)',
+    r'\(e-Reader\)', r'\(FamicomBox\)', r'Animal Crossing',
+    r'Sonic Classic Collection', r'Sonic Mega Collection',
+    r'Disney Classic Games', r'Castlevania Anniversary',
+    r'Castlevania Advance Collection', r'Sega Smash Pack',
+    r'Game no Kanzume', r'Sega Game Toshokan',
+    r'SegaNet', r'Sega 3D Classics',
+    r'Capcom Town', r'iam8bit',
+    r'GameCube Edition',
+    r'Genesis Mini', r'Mega Drive Mini',
+    r'Contra Anniversary Collection', r'Konami Collector',
+    r'Arcade Legends',
+]]
+
+COMPILATION_PATTERNS = [re.compile(p) for p in [
+    r'\d+.in.1\b', r'\d+ Super Jogos', r'^\d+-Pak',
+    r'Compilation',
+    r'\+ .+ \+',
+    r'Super Mario All-Stars',
+    r'Double Pack', r'^2 Games in 1', r'^2 Games in One',
+    r'^2.in.1 Game Pack', r'^Combo Pack', r'^2 Game Pack',
+    r'Classics\)', r'Competition Cartridge',
+    r'Twin Pack',
+    r'Super Pack', r'^Double Game!',
+    r'^Plato Courseware\b',
+    r'^Tigercub\s+\d',
+    r'^BCS\s+(Disk|Specialty Disk)\s+\d',
+    r'^Modules\s+Disk\s+\d',
+]]
+
+_HACK_PATTERNS = [re.compile(p, re.IGNORECASE) for p in [
+    r'\[Hack by',
+    r'\[Add by',
+    r'Edition\]',
+    r'\[FastROM',
+    r'\[Bugfix',
+    r'patch\]',
+    r'\[Retranslated\]',
+    r'GBA Script',
+]]
+
+
+# =============================================================================
+# ROM Filename Parsing
+# =============================================================================
+
+def parse_rom_filename(filename: str) -> RomInfo:
+    """Parse a ROM filename and extract metadata."""
+
+    # Remove file extension
+    name = _RE_EXTENSION.sub('', filename)
+
+    # Detect TOSEC naming
+    is_tosec = False
+    first_paren = _RE_REGION.search(name)
+    if first_paren and _RE_TOSEC_DATE.match(f'({first_paren.group(1)})'):
+        is_tosec = True
+
+    is_bios = name.startswith('[BIOS]') or '(BIOS)' in name
+    if name.startswith('_'):
+        is_bios = True
+
+    is_pirate = '(Pirate)' in name
+    is_unlicensed = '(Unl)' in name
+
+    is_beta = bool(_RE_BETA.search(name))
+    is_demo = ('(Demo)' in name or '(demo' in name.lower()
+               or '(Kiosk)' in name or 'Caravan' in name
+               or 'Taikenban' in name
+               or '(Test Program)' in name or '(Program)' in name
+               or '(Tech Demo)' in name
+               or '(SDK' in name or 'Diagnostic' in name
+               or 'Development Card' in name
+               or 'Atari PAM' in name or '(Trade Demo)' in name
+               or 'Boot Disc' in name
+               or 'Kensa' in name)
+    is_promo = ('(Promo)' in name or '(Movie Promo)' in name
+                or 'Present Campaign' in name
+                or 'Senyou Cartridge' in name
+                or 'Hot Mario Campaign' in name)
+    is_sample = '(Sample)' in name
+    is_proto = '(Proto)' in name or bool(_RE_PROTO.search(name))
+
+    # TOSEC-specific flags
+    tosec_cracked = False
+    tosec_verified = False
+    if is_tosec:
+        name_lower = name.lower()
+        if '(demo' in name_lower:
+            is_demo = True
+        for flag_match in _RE_TOSEC_BAD_FLAGS.finditer(name):
+            flag = flag_match.group(1)
+            flag_lower = flag.lower()
+            if flag_lower in ('b', 'o', 'a'):
+                is_beta = True
+            elif flag_lower.startswith('cr'):
+                tosec_cracked = True
+            elif flag == '!':
+                tosec_verified = True
+
+    is_rerelease = any(p.search(name) for p in RERELEASE_PATTERNS)
+    is_compilation = any(p.search(name) for p in COMPILATION_PATTERNS)
+
+    if _RE_MULTI_GAME.search(name) and 'All-Stars' not in name:
+        is_compilation = True
+    if _RE_NUMBERING.search(name):
+        is_compilation = True
+
+    is_lock_on = '(Lock-on Combination)' in name or (
+        'Sonic & Knuckles +' in name and 'Sonic' in name
+    )
+
+    is_translation = bool(_RE_TRANSLATION.search(name))
+
+    if tosec_cracked:
+        is_pirate = True
+    if 'Cracked' in name and not any(
+            x in name for x in ('Crack Down', 'Cracker')):
+        is_pirate = True
+
+    has_hacks = any(p.search(name) for p in _HACK_PATTERNS) or tosec_cracked
+
+    # Extract region and language
+    region = "Unknown"
+    is_english = False
+    revision = 0
+
+    if is_tosec:
+        paren_tokens = _RE_REGION.findall(name)
+        tosec_region_code = None
+        has_lang_tag = False
+
+        for token in paren_tokens[2:]:
+            token_upper = token.upper().strip()
+            if token_upper in _TOSEC_REGION_MAP:
+                tosec_region_code = token_upper
+                region = _TOSEC_REGION_MAP[token_upper]
+            if re.match(r'^[a-z]{2}(?:\s*-\s*[a-z]{2})*$', token.strip()):
+                has_lang_tag = True
+                if re.search(r'\ben\b', token.strip()):
+                    is_english = True
+
+        if (_RE_ENGLISH_TAG.search(name)
+                or re.search(r'\(en\b', name, re.IGNORECASE)):
+            is_english = True
+        elif tosec_region_code in _TOSEC_ENGLISH_REGIONS:
+            is_english = True
+        elif not tosec_region_code and not has_lang_tag:
+            is_english = True
+
+        pre_paren = name[:name.index('(')] if '(' in name else name
+        tosec_rev = _RE_TOSEC_REVISION.search(pre_paren)
+        if tosec_rev:
+            revision = int(tosec_rev.group(1))
+
+        rev_match = _RE_REVISION.search(name)
+        if rev_match:
+            rev_str = rev_match.group(1)
+            rev_val = (int(rev_str) if rev_str.isdigit()
+                       else ord(rev_str[0].upper()) - ord('A') + 1)
+            revision = max(revision, rev_val)
+
+        if tosec_verified:
+            revision += 1
+
+    else:
+        # No-Intro naming
+        region_match = _RE_REGION.search(name)
+        if region_match:
+            region_str = region_match.group(1)
+            nointro_regions = [
+                'USA', 'World', 'Europe', 'Australia', 'Japan', 'Korea',
+                'Brazil', 'France', 'Germany', 'Spain', 'Italy', 'Asia',
+                'Taiwan', 'Hong Kong', 'China']
+            for reg in nointro_regions:
+                if reg in region_str:
+                    region = reg
+                    break
+
+        if _RE_ENGLISH_TAG.search(name):
+            is_english = True
+        if region in ['USA', 'World', 'Europe', 'Australia']:
+            is_english = True
+        if is_translation:
+            is_english = True
+
+        rev_match = _RE_REVISION.search(name)
+        if rev_match:
+            rev_str = rev_match.group(1)
+            if rev_str.isdigit():
+                revision = int(rev_str)
+            else:
+                revision = ord(rev_str[0].upper()) - ord('A') + 1
+
+    # Version numbers (both No-Intro and TOSEC)
+    ver_match = _RE_VERSION.search(name)
+    if ver_match:
+        revision = max(revision,
+                       int(ver_match.group(1)) * 100
+                       + int(ver_match.group(2)))
+
+    # Disc number
+    disc_match = _RE_DISC.search(name)
+    disc_number = int(disc_match.group(1)) if disc_match else 0
+
+    # Extract base title
+    base_title = name
+    base_title = _RE_BRACKETS.sub('', base_title)
+    base_title = _RE_PARENS.sub('', base_title)
+    tosec_rev_match = _RE_TOSEC_REVISION.search(base_title)
+    if tosec_rev_match:
+        revision = max(revision, int(tosec_rev_match.group(1)))
+        base_title = base_title[:tosec_rev_match.start()]
+    title_ver_match = _RE_TITLE_VERSION.search(base_title)
+    if title_ver_match:
+        ver_str = title_ver_match.group(1)
+        base_title = base_title[:title_ver_match.start()]
+        if '.' in ver_str:
+            parts = ver_str.split('.')
+            ver_num = int(parts[0]) * 100 + int(parts[1])
+        else:
+            ver_num = int(ver_str) * 100
+        revision = max(revision, ver_num)
+    base_title = base_title.strip()
+    base_title = _RE_WHITESPACE.sub(' ', base_title)
+
+    homebrew_indicators = ['(Aftermarket)', '(Homebrew)', 'Homebrew']
+    is_homebrew = any(ind in name for ind in homebrew_indicators)
+
+    # Year
+    year = 0
+    if is_tosec and first_paren:
+        date_str = first_paren.group(1)
+        if len(date_str) >= 4 and date_str[:4].isdigit():
+            potential_year = int(date_str[:4])
+            if 1970 <= potential_year <= 2030:
+                year = potential_year
+    year_match = _RE_YEAR.search(name)
+    if year_match:
+        potential_year = int(year_match.group(1))
+        if 1970 <= potential_year <= 2030:
+            year = potential_year
+
+    return RomInfo(
+        filename=filename,
+        base_title=base_title,
+        region=region,
+        revision=revision,
+        is_english=is_english,
+        is_translation=is_translation,
+        is_beta=is_beta,
+        is_demo=is_demo,
+        is_promo=is_promo,
+        is_sample=is_sample,
+        is_proto=is_proto,
+        is_bios=is_bios,
+        is_pirate=is_pirate,
+        is_unlicensed=is_unlicensed,
+        is_homebrew=is_homebrew,
+        is_rerelease=is_rerelease,
+        is_compilation=is_compilation,
+        is_lock_on=is_lock_on,
+        has_hacks=has_hacks,
+        year=year,
+        disc_number=disc_number,
+    )
+
+
+# =============================================================================
+# Best ROM Selection
+# =============================================================================
+
+def select_best_rom(roms: List[RomInfo],
+                    region_priority: List[str] = None,
+                    verbose: bool = False) -> Optional[RomInfo]:
+    """Select the best ROM from a group of ROMs for the same game.
+
+    Priority order:
+    1. English versions (USA/Europe/World)
+    2. English translations of foreign games
+    3. Foreign versions (Japan, etc.) if no English option exists
+    """
+    _ = verbose  # Reserved for future callback-based logging
+    if not roms:
+        return None
+
+    if region_priority is None:
+        region_priority = DEFAULT_REGION_PRIORITY
+
+    # Filter out universally unwanted ROMs
+    base_filtered = []
+    for rom in roms:
+        if rom.is_bios or rom.is_pirate or rom.is_homebrew or rom.is_unlicensed:
+            continue
+        if rom.is_beta or rom.is_demo or rom.is_promo or rom.is_sample:
+            continue
+        if rom.is_rerelease:
+            continue
+        if rom.is_compilation:
+            continue
+        if rom.is_lock_on:
+            continue
+        base_filtered.append(rom)
+
+    if not base_filtered:
+        return None
+
+    # Separate into English and non-English pools
+    english_roms = [r for r in base_filtered if r.is_english]
+    foreign_roms = [r for r in base_filtered if not r.is_english]
+
+    candidates = english_roms if english_roms else foreign_roms
+    if not candidates:
+        return None
+
+    # Separate prototypes from regular releases
+    protos = [r for r in candidates if r.is_proto]
+    regular = [r for r in candidates if not r.is_proto]
+    candidates = regular if regular else protos
+
+    # Prefer official English over translations over untranslated
+    english_regions = {'USA', 'World', 'Europe', 'Australia', 'England'}
+    non_trans = [r for r in candidates if not r.is_translation]
+    translations = [r for r in candidates if r.is_translation]
+
+    english_non_trans = [r for r in non_trans if r.region in english_regions]
+
+    if english_non_trans:
+        non_hacked = [r for r in english_non_trans if not r.has_hacks]
+        candidates = non_hacked if non_hacked else english_non_trans
+    elif translations:
+        pure_trans = [r for r in translations if not r.has_hacks]
+        candidates = pure_trans if pure_trans else translations
+    elif non_trans:
+        non_hacked = [r for r in non_trans if not r.has_hacks]
+        candidates = non_hacked if non_hacked else non_trans
+
+    # Sort by region priority, revision, hacks
+    def sort_key(rom: RomInfo):
+        priority_dict = {
+            reg: idx for idx, reg in enumerate(region_priority)}
+        return (
+            priority_dict.get(rom.region, 99),
+            -rom.revision,
+            1 if rom.has_hacks else 0,
+        )
+
+    candidates.sort(key=sort_key)
+    return candidates[0] if candidates else None
+
+
+def _collect_sibling_discs(best: RomInfo,
+                           group: List[RomInfo]) -> List[RomInfo]:
+    """Given a selected ROM, find all discs of the same game matching
+    its region/revision."""
+    if best.disc_number == 0:
+        return [best]
+    siblings = [r for r in group
+                if r.disc_number > 0
+                and r.region == best.region
+                and r.revision == best.revision
+                and r.is_translation == best.is_translation]
+    siblings.sort(key=lambda r: r.disc_number)
+    return siblings if siblings else [best]
+
+
+# =============================================================================
+# Pattern matching helper
+# =============================================================================
+
+def matches_patterns(name: str, patterns: List[str]) -> bool:
+    """Check if a filename matches any of the glob patterns."""
+    name_lower = name.lower()
+    return any(fnmatch.fnmatch(name_lower, pat.lower()) for pat in patterns)
+
+
+# =============================================================================
+# Console ROM filtering (stub delegates to monolith for local files)
+# =============================================================================
 
 def filter_console_roms(system, rom_files, config, dat_entries=None,
                         on_progress=None):
@@ -11,27 +453,23 @@ def filter_console_roms(system, rom_files, config, dat_entries=None,
     """Filter console ROMs for a system using the v1 engine.
 
     Wraps the monolith's filter_roms_from_files with structured results.
-
-    Args:
-        system: System code (e.g. 'snes').
-        rom_files: List of ROM file paths or URLs.
-        config: Configuration object.
-        dat_entries: Optional pre-loaded DAT entries dict.
-        on_progress: Optional callback for progress updates.
-
-    Returns:
-        FilterResult with selected/excluded ROMs and statistics.
+    Local filtering has many deep dependencies (transfer, budget, etc.),
+    so it still delegates to the monolith.
     """
-    _ = rom_files, config, dat_entries, on_progress  # Will be wired later
+    _ = rom_files, config, dat_entries, on_progress
     return FilterResult(system=system)
 
+
+# =============================================================================
+# Network ROM filtering (standalone)
+# =============================================================================
 
 def filter_network_roms(system, urls, config, url_sizes=None,
                         dat_entries=None, on_progress=None):
     # type: (str, List[str], Config, Dict[str, int], dict, Callable) -> FilterResult
     """Filter network ROM URLs for a console system.
 
-    Wraps the monolith's network ROM filtering with structured results.
+    Standalone implementation -- does not depend on the monolith.
 
     Args:
         system: System code.
@@ -44,5 +482,138 @@ def filter_network_roms(system, urls, config, url_sizes=None,
     Returns:
         FilterResult with selected/excluded URLs and statistics.
     """
-    _ = urls, config, url_sizes, dat_entries, on_progress  # Will be wired later
-    return FilterResult(system=system)
+    _ = on_progress
+
+    if not urls:
+        return FilterResult(system=system)
+
+    sel = config.selection
+    region_priority = sel.region_priority or DEFAULT_REGION_PRIORITY
+    keep_regions = (sel.keep_regions.split(',')
+                    if sel.keep_regions else None)
+    no_filter = sel.all_roms
+    if url_sizes is None:
+        url_sizes = {}
+
+    # Build filename -> DAT name lookup for better title matching
+    dat_name_lookup: Dict[str, str] = {}
+    if dat_entries:
+        for _, entry in dat_entries.items():
+            rom_base = Path(entry.rom_name).stem.lower()
+            dat_name_lookup[rom_base] = entry.name
+
+    # Parse all ROMs from URLs
+    all_roms: List[RomInfo] = []
+    url_map: Dict[str, str] = {}
+    size_map: Dict[str, int] = {}
+    total_source_size = 0
+
+    for url in urls:
+        filename = get_filename_from_url(url)
+
+        if not no_filter:
+            if (sel.include_patterns
+                    and not matches_patterns(filename, sel.include_patterns)):
+                continue
+            if (sel.exclude_patterns
+                    and matches_patterns(filename, sel.exclude_patterns)):
+                continue
+
+        rom_info = parse_rom_filename(filename)
+
+        if not no_filter:
+            if rom_info.is_proto and sel.exclude_protos:
+                continue
+            if rom_info.is_beta and not sel.include_betas:
+                continue
+            if rom_info.is_unlicensed and not sel.include_unlicensed:
+                continue
+
+            if rom_info.year > 0:
+                if sel.year_from and rom_info.year < sel.year_from:
+                    continue
+                if sel.year_to and rom_info.year > sel.year_to:
+                    continue
+
+        all_roms.append(rom_info)
+        url_map[filename] = url
+        file_size = url_sizes.get(url, 0)
+        size_map[filename] = file_size
+        total_source_size += file_size
+
+    if no_filter:
+        selected_urls = [url_map[rom.filename]
+                         for rom in all_roms if rom.filename in url_map]
+    else:
+        # Group by normalized title
+        grouped: Dict[str, List[RomInfo]] = defaultdict(list)
+        for rom in all_roms:
+            rom_base = Path(rom.filename).stem.lower()
+            if rom_base in dat_name_lookup:
+                dat_name = dat_name_lookup[rom_base]
+                dat_rom_info = parse_rom_filename(dat_name + '.zip')
+                normalized = normalize_title(dat_rom_info.base_title)
+            else:
+                normalized = normalize_title(rom.base_title)
+            grouped[normalized].append(rom)
+
+        selected_urls = []
+        selected_roms_list: List[RomInfo] = []
+        for _title, roms in grouped.items():
+            if keep_regions:
+                seen_regions: set = set()
+                for reg in keep_regions:
+                    for rom in sorted(roms, key=lambda r: (
+                            r.is_translation, r.has_hacks, -r.revision)):
+                        if rom.region == reg and reg not in seen_regions:
+                            if rom.filename in url_map:
+                                for sibling in _collect_sibling_discs(
+                                        rom, roms):
+                                    if sibling.filename in url_map:
+                                        selected_urls.append(
+                                            url_map[sibling.filename])
+                                        selected_roms_list.append(sibling)
+                                seen_regions.add(reg)
+                            break
+                if not seen_regions:
+                    best = select_best_rom(roms, region_priority)
+                    if best and best.filename in url_map:
+                        for sibling in _collect_sibling_discs(best, roms):
+                            if sibling.filename in url_map:
+                                selected_urls.append(
+                                    url_map[sibling.filename])
+                                selected_roms_list.append(sibling)
+            else:
+                best = select_best_rom(roms, region_priority)
+                if best and best.filename in url_map:
+                    for sibling in _collect_sibling_discs(best, roms):
+                        if sibling.filename in url_map:
+                            selected_urls.append(url_map[sibling.filename])
+                            selected_roms_list.append(sibling)
+
+        # Apply english-only filter
+        if sel.english_only:
+            english_pairs = [(u, r) for u, r in zip(
+                selected_urls, selected_roms_list) if r.is_english]
+            if english_pairs:
+                selected_urls = [p[0] for p in english_pairs]
+            else:
+                selected_urls = []
+
+    selected_size = sum(
+        size_map.get(get_filename_from_url(u), 0) for u in selected_urls)
+
+    stats = FilterStats(
+        source_count=len(urls),
+        selected_count=len(selected_urls),
+        excluded_count=len(urls) - len(selected_urls),
+        source_size=total_source_size,
+        selected_size=selected_size,
+    )
+
+    result = FilterResult(system=system, selected=selected_urls, stats=stats)
+    result.size_info = {
+        'source_size': total_source_size,
+        'selected_size': selected_size,
+    }
+    return result

--- a/retro_refiner/mame.py
+++ b/retro_refiner/mame.py
@@ -1,40 +1,737 @@
-"""MAME-specific filtering: category filtering, clone selection, CHD handling."""
+"""MAME-specific filtering: category filtering, clone selection, CHD handling.
+
+Standalone implementations extracted from the monolith.  Console output is
+replaced by optional callbacks and plain stderr for errors.
+"""
+import fnmatch
+import json
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional, Tuple
 
 from retro_refiner.config import Config
 from retro_refiner.models import FilterResult
 
 
-def filter_mame_network(urls, config, url_sizes=None, on_progress=None):
+# =============================================================================
+# Dataclass
+# =============================================================================
+
+@dataclass
+class MameGameInfo:
+    """Information about a MAME game parsed from DAT and catver.ini."""
+    name: str
+    description: str
+    year: str
+    manufacturer: str
+    category: str
+    is_parent: bool
+    parent_name: str
+    is_bios: bool
+    is_device: bool
+    has_chd: bool
+    chd_names: list
+    region: str
+    bios_name: str = ''
+    rom_files: list = None
+
+
+# =============================================================================
+# Category sets
+# =============================================================================
+
+MAME_INCLUDE_CATEGORIES = {
+    'Ball & Paddle', 'Climbing', 'Fighter', 'Maze', 'Platform',
+    'Puzzle', 'Shooter', 'Sports', 'Whac-A-Mole', 'Driving',
+    'Multiplay', 'MultiGame', 'TTL',
+}
+
+MAME_EXCLUDE_CATEGORIES = {
+    'Casino', 'Gambling', 'Quiz',
+    'Tabletop / Mahjong', 'Tabletop / Hanafuda',
+    'Slot Machine',
+    'Electromechanical',
+    'Arcade / Strength Tester', 'Arcade / Fortune Teller',
+    'Arcade / Physical Ability',
+    'Music Game / Dance', 'Music Game / Instruments',
+    'Redemption Game', 'Medal Game',
+    'System / BIOS', 'System / Device',
+    'Computer', 'Calculator', 'Printer', 'Telephone',
+    'Utilities', 'Medical Equipment', 'Musical Instrument',
+    'Radio', 'Watch', 'Misc. / Clock', 'Misc. / Prediction',
+    'Misc. / Love Test', 'Game Console', 'Handheld',
+    'Board Game', 'Music Player', 'Player', 'Tablet',
+    'TV Bundle', 'Non Arcade', 'Digital Camera',
+    'Digital Simulator', 'Robot', 'Simulation',
+    'Card Games / Solitaire',
+}
+
+MAME_EXCLUDE_SUBCATEGORIES = {
+    'Music Game / Dance',
+    "Handheld / Plug n' Play TV Game / Dance",
+    "Handheld / Plug n' Play TV Game / Mahjong",
+    "Handheld / Plug n' Play TV Game / Quiz",
+    "Handheld / Plug n' Play TV Game / Casino",
+    'Tabletop / Mahjong',
+    'Tabletop / Mahjong * Mature *',
+    'Tabletop / Hanafuda',
+    'Tabletop / Hanafuda * Mature *',
+}
+
+
+# =============================================================================
+# MAME version / download constants
+# =============================================================================
+
+DEFAULT_MAME_VERSION = "0.274"
+
+
+def get_latest_mame_version() -> str:
+    """Try to detect the latest MAME version from GitHub releases."""
+    try:
+        url = "https://api.github.com/repos/mamedev/mame/releases/latest"
+        req = urllib.request.Request(
+            url, headers={'User-Agent': 'Retro-Refiner/1.0'})
+        with urllib.request.urlopen(req, timeout=10) as response:
+            data = json.loads(response.read().decode())
+            tag = data.get('tag_name', '')
+            if tag.startswith('mame'):
+                version_num = tag[4:]
+                if len(version_num) >= 4:
+                    return f"0.{version_num[1:]}"
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return DEFAULT_MAME_VERSION
+
+
+def _download_file(url: str, dest_path: Path,
+                   description: str = "file") -> bool:
+    """Download a file from URL to destination path."""
+    _ = description  # Logged in monolith; kept for API compat
+    try:
+        req = urllib.request.Request(
+            url, headers={'User-Agent': 'Retro-Refiner/1.0'})
+        with urllib.request.urlopen(req, timeout=60) as response:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(dest_path, 'wb') as fh:
+                shutil.copyfileobj(response, fh)
+        return True
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _extract_from_zip(zip_path: Path, filename: str,
+                      dest_path: Path) -> bool:
+    """Extract a specific file from a zip archive."""
+    try:
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for name in zf.namelist():
+                if name.endswith(filename) or name == filename:
+                    with zf.open(name) as src:
+                        dest_path.parent.mkdir(parents=True, exist_ok=True)
+                        with open(dest_path, 'wb') as dst:
+                            shutil.copyfileobj(src, dst)
+                    return True
+        return False
+    except (zipfile.BadZipFile, Exception):
+        return False
+
+
+def download_mame_data(dat_dir, version=None, force=False,
+                       on_progress=None):
+    # type: (Path, Optional[str], bool, Callable) -> tuple
+    """Download MAME catver.ini and DAT files.
+
+    Returns (catver_path, dat_path) or (None, None) on failure.
+    """
+    _ = on_progress
+    dat_dir = Path(dat_dir)
+
+    if version is None:
+        version = get_latest_mame_version()
+
+    version_clean = version.replace(".", "")
+    dat_dir.mkdir(parents=True, exist_ok=True)
+
+    catver_path = dat_dir / 'catver.ini'
+    dat_path = dat_dir / 'mame.xml'
+
+    if force:
+        if catver_path.exists():
+            catver_path.unlink()
+        if dat_path.exists():
+            dat_path.unlink()
+
+    # Download catver.ini
+    if not catver_path.exists():
+        alt_version = version_clean.lstrip('0')
+        catver_url = (
+            "https://www.progettosnaps.net/download/"
+            f"?tipo=catver&file=pS_CatVer_{alt_version}.zip")
+        zip_path = dat_dir / 'catver.zip'
+
+        if _download_file(catver_url, zip_path, "catver.ini pack"):
+            if _extract_from_zip(zip_path, 'catver.ini', catver_path):
+                zip_path.unlink()
+        else:
+            prev_version = str(int(alt_version) - 1)
+            catver_url = (
+                "https://www.progettosnaps.net/download/"
+                f"?tipo=catver&file=pS_CatVer_{prev_version}.zip")
+            if _download_file(catver_url, zip_path,
+                              "catver.ini pack (prev version)"):
+                if _extract_from_zip(zip_path, 'catver.ini', catver_path):
+                    zip_path.unlink()
+
+    # Download MAME XML/DAT
+    if not dat_path.exists():
+        mame_xml_url = (
+            f"https://github.com/mamedev/mame/releases/download/"
+            f"mame{version_clean}/mame{version_clean}lx.zip")
+        zip_path = dat_dir / 'mame_xml.zip'
+
+        if _download_file(mame_xml_url, zip_path, "MAME XML"):
+            if _extract_from_zip(zip_path, '.xml', dat_path):
+                zip_path.unlink()
+        else:
+            alt_version = version_clean.lstrip('0')
+            alt_url = (
+                "https://www.progettosnaps.net/download/"
+                f"?tipo=dat_mame&file=/dats/MAME/packs/"
+                f"MAME_Dats_{alt_version}.7z")
+            archive_path = dat_dir / 'mame_dats.7z'
+            if _download_file(alt_url, archive_path, "MAME DAT pack"):
+                try:
+                    result = subprocess.run(
+                        ['7z', 'x', '-y', f'-o{dat_dir}',
+                         str(archive_path)],
+                        capture_output=True, text=True, check=False)
+                    if result.returncode == 0:
+                        for dat in dat_dir.glob('*arcade*.dat'):
+                            dat.rename(dat_path)
+                            break
+                        archive_path.unlink()
+                except FileNotFoundError:
+                    pass
+
+    if catver_path.exists() and dat_path.exists():
+        return catver_path, dat_path
+    if catver_path.exists():
+        existing_dats = (list(dat_dir.glob('*.dat'))
+                         + list(dat_dir.glob('*.xml')))
+        if existing_dats:
+            return catver_path, existing_dats[0]
+
+    return (catver_path if catver_path.exists() else None,
+            dat_path if dat_path.exists() else None)
+
+
+# =============================================================================
+# Parsing
+# =============================================================================
+
+def parse_catver_ini(catver_path: str) -> dict:
+    """Parse catver.ini and return a dict of romname -> category."""
+    categories = {}
+    in_category_section = False
+
+    with open(catver_path, 'r', encoding='utf-8', errors='ignore') as fh:
+        for line in fh:
+            line = line.strip()
+            if line == '[Category]':
+                in_category_section = True
+                continue
+            if line.startswith('[') and in_category_section:
+                break
+            if in_category_section and '=' in line:
+                parts = line.split('=', 1)
+                if len(parts) == 2:
+                    romname = parts[0].strip()
+                    category = parts[1].strip()
+                    categories[romname] = category
+
+    return categories
+
+
+def parse_mame_dat(dat_path: str) -> dict:
+    """Parse MAME DAT file and return game info dict.
+
+    Returns dict mapping ROM name -> MameGameInfo.
+    """
+    games = {}
+
+    with open(dat_path, 'r', encoding='utf-8', errors='ignore') as fh:
+        first_line = fh.readline()
+
+    if not ('<?xml' in first_line or '<datafile' in first_line
+            or '<mame' in first_line):
+        return games
+
+    game_tags = ('machine', 'game')
+
+    parser = ET.XMLPullParser(events=('end',))
+    with open(dat_path, 'rb') as fh:
+        while True:
+            chunk = fh.read(65536)
+            if not chunk:
+                break
+            parser.feed(chunk)
+            for _, elem in parser.read_events():
+                if elem.tag not in game_tags:
+                    continue
+
+                name = elem.get('name', '')
+                if not name:
+                    elem.clear()
+                    continue
+
+                is_bios = elem.get('isbios', 'no') == 'yes'
+                is_device = elem.get('isdevice', 'no') == 'yes'
+
+                cloneof = elem.get('cloneof', '')
+                romof = elem.get('romof', '')
+                parent_name = cloneof
+                is_parent = not cloneof or cloneof == name
+                bios_name = (romof if romof and romof != cloneof
+                             else '')
+
+                desc_elem = elem.find('description')
+                description = (desc_elem.text
+                               if desc_elem is not None else name)
+
+                year_elem = elem.find('year')
+                year_val = year_elem.text if year_elem is not None else ''
+
+                mfr_elem = (elem.find('manufacturer')
+                            or elem.find('publisher'))
+                manufacturer = (mfr_elem.text
+                                if mfr_elem is not None else '')
+
+                chd_names = []
+                for disk in elem.findall('.//disk'):
+                    disk_name = disk.get('name', '')
+                    if disk_name:
+                        chd_names.append(disk_name + '.chd')
+
+                rom_files = []
+                for rom_elem in elem.findall('.//rom'):
+                    rom_name_attr = rom_elem.get('name', '')
+                    if rom_name_attr:
+                        rom_files.append(rom_name_attr)
+
+                region = detect_mame_region(description)
+
+                games[name] = MameGameInfo(
+                    name=name,
+                    description=description,
+                    year=year_val,
+                    manufacturer=manufacturer or '',
+                    category='',
+                    is_parent=is_parent,
+                    parent_name=parent_name if not is_parent else '',
+                    is_bios=is_bios,
+                    is_device=is_device,
+                    has_chd=bool(chd_names),
+                    chd_names=chd_names,
+                    region=region,
+                    bios_name=bios_name,
+                    rom_files=rom_files,
+                )
+                elem.clear()
+
+    return games
+
+
+def detect_mame_region(description: str) -> str:
+    """Detect region from MAME game description."""
+    desc_lower = description.lower()
+
+    if '(us)' in desc_lower or '(usa)' in desc_lower or '[us]' in desc_lower:
+        return 'USA'
+    if '(world)' in desc_lower or '[world]' in desc_lower:
+        return 'World'
+    if ('(europe)' in desc_lower or '(euro)' in desc_lower
+            or '[europe]' in desc_lower):
+        return 'Europe'
+    if ('(japan)' in desc_lower or '(jpn)' in desc_lower
+            or '[japan]' in desc_lower):
+        return 'Japan'
+    if '(asia)' in desc_lower or '[asia]' in desc_lower:
+        return 'Asia'
+    if '(korea)' in desc_lower or '[korea]' in desc_lower:
+        return 'Korea'
+    if '(hispanic)' in desc_lower or '(brazil)' in desc_lower:
+        return 'LatinAmerica'
+
+    if ' usa ' in desc_lower or desc_lower.endswith(' usa'):
+        return 'USA'
+
+    return 'Unknown'
+
+
+# =============================================================================
+# Game filtering decisions
+# =============================================================================
+
+def should_include_mame_game(game: MameGameInfo, category: str,
+                             include_adult: bool = True) -> tuple:
+    """Determine if a MAME game should be included.
+
+    Returns (should_include, reason).
+    """
+    if game.is_bios:
+        return False, "BIOS"
+    if game.is_device:
+        return False, "Device"
+
+    if not category:
+        return False, "No category"
+
+    if not include_adult and '* Mature *' in category:
+        return False, "Adult/mature content"
+
+    if category in MAME_EXCLUDE_SUBCATEGORIES:
+        return False, f"Excluded subcategory: {category}"
+
+    for exclude_cat in MAME_EXCLUDE_CATEGORIES:
+        if category.startswith(exclude_cat):
+            return False, f"Excluded category: {exclude_cat}"
+
+    cat_lower = category.lower()
+    if 'mahjong' in cat_lower:
+        return False, "Mahjong game"
+    if 'quiz' in cat_lower:
+        return False, "Quiz game"
+    if 'casino' in cat_lower or 'gambling' in cat_lower:
+        return False, "Casino/Gambling game"
+    if 'slot machine' in cat_lower:
+        return False, "Slot machine"
+    if 'pachinko' in cat_lower:
+        return False, "Pachinko"
+    if 'medal game' in cat_lower:
+        return False, "Medal game"
+    if 'dance' in cat_lower and 'game' in cat_lower:
+        return False, "Dance game (requires pad)"
+
+    for include_cat in MAME_INCLUDE_CATEGORIES:
+        if category.startswith(include_cat):
+            return True, f"Included category: {include_cat}"
+
+    if 'pinball' in cat_lower and 'electromechanical' not in cat_lower:
+        return True, "Video pinball"
+
+    if 'shooter / gallery' in cat_lower or 'gun' in cat_lower:
+        return True, "Light gun game"
+
+    return False, f"Unknown category: {category}"
+
+
+def get_mame_region_priority(region: str) -> int:
+    """Get priority for MAME regions (lower is better)."""
+    priorities = {
+        'USA': 0, 'World': 1, 'Europe': 2, 'Asia': 3,
+        'Japan': 4, 'Korea': 5, 'LatinAmerica': 6, 'Unknown': 10,
+    }
+    return priorities.get(region, 10)
+
+
+def select_best_mame_clone(parent_name: str, clones: list,
+                           games: dict,
+                           verbose: bool = False) -> Optional[MameGameInfo]:
+    """Select the best clone based on region preference."""
+    _ = verbose  # Reserved for future callback-based logging
+    if not clones:
+        return games.get(parent_name)
+
+    candidates = ([games[parent_name]] if parent_name in games else [])
+    candidates.extend([games[c] for c in clones if c in games])
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda g: get_mame_region_priority(g.region))
+    return candidates[0]
+
+
+# =============================================================================
+# ROM set format detection and dependency resolution
+# =============================================================================
+
+def detect_mame_set_format(source_path, games, available_roms):
+    """Detect MAME ROM set format: 'merged', 'split', or 'non-merged'.
+
+    Checks up to 5 parent/clone groups using majority vote.
+    """
+    source_path = Path(source_path)
+    parent_clones = defaultdict(list)
+    for name, game in games.items():
+        if not game.is_parent and game.parent_name:
+            parent_clones[game.parent_name].append(name)
+
+    votes = []
+    for parent_name, clones in parent_clones.items():
+        if len(votes) >= 5:
+            break
+        if parent_name not in available_roms:
+            continue
+
+        clone_zips_exist = [c for c in clones if c in available_roms]
+
+        if not clone_zips_exist:
+            votes.append('merged')
+            continue
+
+        clone_name = clone_zips_exist[0]
+        clone_zip_path = source_path / f"{clone_name}.zip"
+        parent_game = games.get(parent_name)
+
+        if (not parent_game or not parent_game.rom_files
+                or not clone_zip_path.exists()):
+            votes.append('non-merged')
+            continue
+
+        try:
+            with zipfile.ZipFile(clone_zip_path, 'r') as zf:
+                clone_contents = set(zf.namelist())
+            parent_rom_set = set(parent_game.rom_files)
+            overlap = parent_rom_set & clone_contents
+            if len(overlap) > len(parent_rom_set) * 0.5:
+                votes.append('non-merged')
+            else:
+                votes.append('split')
+        except (zipfile.BadZipFile, OSError):
+            votes.append('non-merged')
+
+    if not votes:
+        return 'non-merged'
+
+    vote_counts = Counter(votes)
+    return vote_counts.most_common(1)[0][0]
+
+
+def build_mame_copy_set(selected_roms, games, available_roms, set_format):
+    """Build the set of zip names to copy based on ROM set format.
+
+    Returns (copy_set, dependency_list) where copy_set is a set of ROM
+    names and dependency_list is a list of (name, reason) tuples.
+    """
+    copy_set = set()
+    dependencies = []
+
+    if set_format == 'non-merged':
+        for game in selected_roms:
+            if game.name in available_roms:
+                copy_set.add(game.name)
+    elif set_format == 'split':
+        for game in selected_roms:
+            if game.name in available_roms:
+                copy_set.add(game.name)
+            if not game.is_parent and game.parent_name:
+                if (game.parent_name in available_roms
+                        and game.parent_name not in copy_set):
+                    dependencies.append(
+                        (game.parent_name, f"parent of {game.name}"))
+                copy_set.add(game.parent_name)
+    elif set_format == 'merged':
+        for game in selected_roms:
+            if game.name in available_roms:
+                copy_set.add(game.name)
+            elif (game.parent_name
+                  and game.parent_name in available_roms):
+                if game.parent_name not in copy_set:
+                    dependencies.append(
+                        (game.parent_name,
+                         f"merged parent, contains {game.name}"))
+                copy_set.add(game.parent_name)
+
+    # Collect required BIOS zips
+    required_bios = set()
+    for game in selected_roms:
+        if game.bios_name and game.bios_name in available_roms:
+            required_bios.add(game.bios_name)
+        if game.parent_name:
+            parent = games.get(game.parent_name)
+            if (parent and parent.bios_name
+                    and parent.bios_name in available_roms):
+                required_bios.add(parent.bios_name)
+
+    for bios_name in required_bios:
+        if bios_name not in copy_set:
+            dependencies.append((bios_name, "BIOS"))
+        copy_set.add(bios_name)
+
+    return copy_set, dependencies
+
+
+# =============================================================================
+# Network MAME filtering (standalone)
+# =============================================================================
+
+def filter_mame_network(urls, config, url_sizes=None,
+                        on_progress=None):
     # type: (List[str], Config, Dict[str, int], Callable) -> FilterResult
     """Filter MAME network ROM URLs.
 
-    Args:
-        urls: List of MAME ROM URLs.
-        config: Configuration object.
-        url_sizes: Optional dict of URL -> file size.
-        on_progress: Optional callback for progress updates.
-
-    Returns:
-        FilterResult with selected/excluded MAME ROMs.
+    This is a stub that returns an empty FilterResult.
+    The full network filtering requires pre-loaded categories and games
+    dicts, which are loaded separately via parse_catver_ini / parse_mame_dat.
+    Use filter_mame_network_roms() for the full implementation.
     """
-    _ = urls, config, url_sizes, on_progress  # Will be wired later
+    _ = urls, config, url_sizes, on_progress
     return FilterResult(system='mame')
 
 
-def download_mame_data(dat_dir, version=None, on_progress=None):
-    # type: (Path, str, Callable) -> tuple
-    """Download MAME catver.ini and DAT files.
+def filter_mame_network_roms(rom_urls, categories, games,
+                             include_patterns=None,
+                             exclude_patterns=None,
+                             include_adult=True,
+                             url_sizes=None,
+                             verbose=False,
+                             no_filter=False,
+                             english_only=False):
+    # type: (List[str], dict, dict, list, list, bool, dict, bool, bool, bool) -> Tuple[List[str], dict]
+    """Filter MAME/FBNeo ROMs from network sources using category filtering.
 
-    Args:
-        dat_dir: Directory to store downloaded files.
-        version: Optional MAME version string.
-        on_progress: Optional progress callback.
+    Standalone implementation extracted from the monolith.
 
     Returns:
-        Tuple of (catver_path, dat_path) or similar from the monolith.
+        (selected_urls, size_info_dict)
     """
-    _ = on_progress  # Reserved for future progress reporting
-    from retro_refiner._monolith import get_module  # pylint: disable=import-outside-toplevel
-    return get_module().download_mame_data(dat_dir, version=version)
+    if url_sizes is None:
+        url_sizes = {}
+
+    url_map: Dict[str, str] = {}
+    size_map: Dict[str, int] = {}
+    url_game_map: Dict[str, str] = {}
+    total_source_size = 0
+
+    for url in rom_urls:
+        url_clean = url.split('?')[0].split('#')[0]
+        filename = urllib.request.unquote(url_clean.split('/')[-1])
+        url_map[filename] = url
+        size = url_sizes.get(url, 0)
+        size_map[filename] = size
+        total_source_size += size
+        url_parts = url_clean.rstrip('/').split('/')
+        if len(url_parts) >= 2:
+            parent_folder = urllib.request.unquote(url_parts[-2])
+            url_game_map[filename] = parent_folder
+
+    # Build CHD name -> parent game lookup
+    chd_to_game: Dict[str, str] = {}
+    for name, game in games.items():
+        if game.chd_names:
+            for chd_name in game.chd_names:
+                chd_to_game[chd_name] = name
+
+    for name, game in games.items():
+        if not game.category:
+            game.category = categories.get(name, '')
+
+    parent_clones: Dict[str, List[str]] = defaultdict(list)
+    for name, game in games.items():
+        if not game.is_parent and game.parent_name:
+            parent_clones[game.parent_name].append(name)
+
+    selected_urls: List[str] = []
+    selected_size = 0
+    excluded_counts: Dict[str, int] = defaultdict(int)
+
+    if no_filter:
+        selected_urls = list(url_map.values())
+        selected_size = sum(size_map.values())
+    else:
+        processed: set = set()
+
+        for filename, url in url_map.items():
+            rom_name = (filename.rsplit('.', 1)[0]
+                        if '.' in filename else filename)
+
+            if rom_name in processed:
+                continue
+
+            if include_patterns:
+                if not any(fnmatch.fnmatch(filename.lower(), pat.lower())
+                           for pat in include_patterns):
+                    excluded_counts['pattern exclude'] += 1
+                    continue
+            if exclude_patterns:
+                if any(fnmatch.fnmatch(filename.lower(), pat.lower())
+                       for pat in exclude_patterns):
+                    excluded_counts['pattern exclude'] += 1
+                    continue
+
+            game = games.get(rom_name)
+            if not game and rom_name in chd_to_game:
+                rom_name = chd_to_game[rom_name]
+                game = games.get(rom_name)
+            if not game and filename in url_game_map:
+                folder_game = url_game_map[filename]
+                if folder_game in games:
+                    rom_name = folder_game
+                    game = games[folder_game]
+            if not game:
+                selected_urls.append(url)
+                selected_size += size_map.get(filename, 0)
+                processed.add(rom_name)
+                continue
+
+            if not game.is_parent and game.parent_name:
+                parent_name = game.parent_name
+                if parent_name in processed:
+                    continue
+                parent_game = games.get(parent_name)
+                if parent_game:
+                    game = parent_game
+                    rom_name = parent_name
+
+            category = categories.get(rom_name, game.category or '')
+            should_include, reason = should_include_mame_game(
+                game, category, include_adult)
+
+            if not should_include:
+                excluded_counts[reason] += 1
+                processed.add(rom_name)
+                for clone in parent_clones.get(rom_name, []):
+                    processed.add(clone)
+                continue
+
+            best_rom = select_best_mame_clone(
+                rom_name, parent_clones.get(rom_name, []), games,
+                verbose=verbose)
+            if not best_rom:
+                best_rom = game
+
+            if (english_only
+                    and best_rom.region in (
+                        'Japan', 'Korea', 'LatinAmerica')):
+                excluded_counts[
+                    f'Non-English ({best_rom.region})'] += 1
+                processed.add(rom_name)
+                for clone in parent_clones.get(rom_name, []):
+                    processed.add(clone)
+                continue
+
+            best_filename = f"{best_rom.name}.zip"
+            if best_filename in url_map:
+                selected_urls.append(url_map[best_filename])
+                selected_size += size_map.get(best_filename, 0)
+            elif filename in url_map:
+                selected_urls.append(url)
+                selected_size += size_map.get(filename, 0)
+
+            processed.add(rom_name)
+            for clone in parent_clones.get(rom_name, []):
+                processed.add(clone)
+
+    return selected_urls, {
+        'source_size': total_source_size,
+        'selected_size': selected_size,
+    }

--- a/retro_refiner/teknoparrot.py
+++ b/retro_refiner/teknoparrot.py
@@ -1,23 +1,529 @@
-"""TeknoParrot-specific filtering: version dedup, platform filtering."""
-from typing import Callable, Dict, List
+"""TeknoParrot-specific filtering: version dedup, platform filtering.
+
+Standalone implementations extracted from the monolith.  Console output is
+replaced by optional callbacks and plain stderr for errors.
+"""
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
 
 from retro_refiner.config import Config
 from retro_refiner.models import FilterResult
+from retro_refiner.network import get_filename_from_url
 
+from retro_refiner.filter import matches_patterns
+
+
+# =============================================================================
+# Dataclass
+# =============================================================================
+
+@dataclass
+class TeknoParrotGameInfo:
+    """Information about a TeknoParrot ROM parsed from filename or DAT.
+
+    TeknoParrot ROM naming format:
+    Game Title (Version) (Date) [Hardware Platform] [TP].zip
+    """
+    filename: str
+    name: str
+    base_title: str
+    description: str
+    version: str
+    version_tuple: tuple
+    date: str
+    year: int
+    region: str
+    platform: str
+    is_parent: bool
+    parent_name: str
+    has_chd: bool
+    chd_names: list
+
+
+# =============================================================================
+# Platform sets
+# =============================================================================
+
+TEKNOPARROT_INCLUDE_PLATFORMS = {
+    'Sega Lindbergh', 'Sega RingEdge', 'Sega RingEdge 2',
+    'Sega RingWide', 'Sega Nu', 'Sega Nu 1.1', 'Sega Nu 2',
+    'Sega ALLS', 'Sega ALLS UX',
+    'Taito Type X', 'Taito Type X2', 'Taito Type X3', 'Taito Type X4',
+    'Taito NESiCAxLive', 'Taito NESiCAxLive 2',
+    'Namco System 246', 'Namco System 256', 'Namco System 357',
+    'Namco System ES1', 'Namco System ES3',
+    'Examu eX-BOARD', 'Raw Thrills PC', 'IGS PGM2',
+    'Konami PC', 'Windows PC',
+}
+
+TEKNOPARROT_EXCLUDE_PLATFORMS: set = set()
+
+
+# =============================================================================
+# Version parsing
+# =============================================================================
+
+def parse_teknoparrot_version(version_str: str) -> tuple:
+    """Parse a version string into a comparable tuple.
+
+    Handles formats like: "1.30.01", "Ver.2", "2.30.00", "Rev.6"
+    """
+    if not version_str:
+        return (0,)
+
+    version_str = re.sub(
+        r'^(Ver\.?|Version|Rev\.?|v)\s*', '', version_str,
+        flags=re.IGNORECASE)
+
+    parts = re.findall(r'\d+', version_str)
+    if parts:
+        return tuple(int(p) for p in parts)
+    return (0,)
+
+
+# =============================================================================
+# Filename parsing
+# =============================================================================
+
+def parse_teknoparrot_filename(
+        filename: str) -> Optional[TeknoParrotGameInfo]:
+    """Parse a TeknoParrot ROM filename into structured info.
+
+    Expected format: Game Title (Version) (Date) [Hardware Platform] [TP].zip
+    """
+    if '[TP]' not in filename and '[tp]' not in filename.lower():
+        return None
+
+    name = filename
+    for ext in ('.zip', '.7z', '.rar'):
+        if name.lower().endswith(ext):
+            name = name[:-len(ext)]
+            break
+
+    # Extract hardware platform
+    platform_match = re.search(
+        r'\[([^\]]+)\](?=.*\[TP\])', name, re.IGNORECASE)
+    platform = platform_match.group(1) if platform_match else 'Unknown'
+
+    # Remove [TP] tag and platform
+    clean_name = re.sub(r'\s*\[TP\]\s*', '', name, flags=re.IGNORECASE)
+    clean_name = re.sub(r'\s*\[[^\]]+\]\s*$', '', clean_name)
+
+    # Extract version
+    version = ''
+    version_tuple = (0,)
+    version_patterns = [
+        r'\((\d+\.\d+(?:\.\d+)?)\)',
+        r'Ver\.?\s*(\d+(?:\.\d+)*)',
+        r'\((Rev\.?\s*\d+[^\)]*)\)',
+    ]
+    for pattern in version_patterns:
+        match = re.search(pattern, clean_name, re.IGNORECASE)
+        if match:
+            version = match.group(1)
+            version_tuple = parse_teknoparrot_version(version)
+            break
+
+    # Extract date
+    date = ''
+    year = 0
+    date_match = re.search(r'\((\d{4}(?:-\d{2}-\d{2})?)\)', clean_name)
+    if date_match:
+        date = date_match.group(1)
+        year = int(date[:4])
+
+    # Extract region
+    region = 'World'
+    region_patterns = [
+        (r'\(Export\)', 'Export'),
+        (r'\(USA\)', 'USA'),
+        (r'\(Japan\)', 'Japan'),
+        (r'\(Asia\)', 'Asia'),
+        (r'\(Europe\)', 'Europe'),
+        (r'\(Korea\)', 'Korea'),
+        (r'\(World\)', 'World'),
+        (r'[\[\(]En[\]\)]', 'Export'),
+    ]
+    for pattern, reg in region_patterns:
+        if re.search(pattern, clean_name, re.IGNORECASE):
+            region = reg
+            break
+
+    # Extract base title
+    base_title = clean_name
+    base_title = re.sub(r'\s*\([^)]*\)\s*', ' ', base_title)
+    base_title = re.sub(
+        r'\s*Ver\.?\s*\d+(?:\.\d+)*\s*', ' ', base_title,
+        flags=re.IGNORECASE)
+    base_title = ' '.join(base_title.split()).strip()
+
+    return TeknoParrotGameInfo(
+        filename=filename,
+        name=name,
+        base_title=base_title,
+        description=name,
+        version=version,
+        version_tuple=version_tuple,
+        date=date,
+        year=year,
+        region=region,
+        platform=platform,
+        is_parent=True,
+        parent_name='',
+        has_chd=False,
+        chd_names=[],
+    )
+
+
+# =============================================================================
+# Title normalization
+# =============================================================================
+
+def normalize_teknoparrot_title(title: str) -> str:
+    """Normalize a TeknoParrot game title for grouping."""
+    normalized = title.lower()
+    normalized = re.sub(
+        r'\s*ver\.?\s*\d+(?:\.\d+)*\s*$', '', normalized,
+        flags=re.IGNORECASE)
+    normalized = re.sub(
+        r'\s*(arcade stage|arcade|stage)\s*$', '', normalized,
+        flags=re.IGNORECASE)
+    normalized = re.sub(r'[^\w\s]', '', normalized)
+    normalized = ' '.join(normalized.split())
+    return normalized
+
+
+# =============================================================================
+# DAT parsing
+# =============================================================================
+
+def parse_teknoparrot_dat(dat_path: str) -> dict:
+    """Parse TeknoParrot DAT file and return game info dict.
+
+    Returns dict mapping ROM name -> TeknoParrotGameInfo.
+    """
+    games = {}
+
+    try:
+        tree = ET.parse(dat_path)
+        root = tree.getroot()
+
+        game_elements = (root.findall('.//game')
+                         or root.findall('.//machine'))
+
+        for game in game_elements:
+            name = game.get('name', '')
+            if not name:
+                continue
+
+            desc_elem = game.find('description')
+            description = (desc_elem.text
+                           if desc_elem is not None else name)
+
+            filename_to_parse = (description if '[TP]' in description
+                                 else f"{name} [TP].zip")
+            info = parse_teknoparrot_filename(filename_to_parse)
+
+            if info:
+                info.name = name
+                info.description = description
+
+                chd_names = []
+                for disk in game.findall('.//disk'):
+                    disk_name = disk.get('name', '')
+                    if disk_name:
+                        chd_names.append(disk_name + '.chd')
+
+                if chd_names:
+                    info.has_chd = True
+                    info.chd_names = chd_names
+
+                games[name] = info
+            else:
+                games[name] = TeknoParrotGameInfo(
+                    filename=f"{name}.zip",
+                    name=name,
+                    base_title=name,
+                    description=description,
+                    version='',
+                    version_tuple=(0,),
+                    date='',
+                    year=0,
+                    region='World',
+                    platform='Unknown',
+                    is_parent=True,
+                    parent_name='',
+                    has_chd=False,
+                    chd_names=[],
+                )
+
+    except ET.ParseError as exc:
+        print(f"TeknoParrot: Error parsing DAT file: {exc}",
+              file=sys.stderr)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"TeknoParrot: Error reading DAT file: {exc}",
+              file=sys.stderr)
+
+    return games
+
+
+def download_teknoparrot_dat(dat_dir: Path,
+                             force: bool = False) -> Optional[Path]:
+    """Download TeknoParrot DAT file from GitHub releases."""
+    dat_path = dat_dir / 'teknoparrot.dat'
+
+    if dat_path.exists() and not force:
+        return dat_path
+
+    dat_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        api_url = ('https://api.github.com/repos/Eggmansworld/'
+                   'Datfiles/releases/tags/teknoparrot')
+        req = urllib.request.Request(api_url)
+        req.add_header('User-Agent', 'retro-refiner/1.0')
+        req.add_header('Accept', 'application/vnd.github.v3+json')
+
+        with urllib.request.urlopen(req, timeout=30) as response:
+            release_data = json.loads(response.read().decode('utf-8'))
+
+        zip_url = None
+        for asset in release_data.get('assets', []):
+            asset_name = asset.get('name', '').lower()
+            if 'teknoparrot' in asset_name and asset_name.endswith('.zip'):
+                zip_url = asset.get('browser_download_url')
+                break
+
+        if not zip_url:
+            return None
+
+        zip_path = dat_dir / 'teknoparrot_dat.zip'
+
+        req = urllib.request.Request(zip_url)
+        req.add_header('User-Agent', 'retro-refiner/1.0')
+
+        with urllib.request.urlopen(req, timeout=60) as response:
+            with open(zip_path, 'wb') as fh:
+                fh.write(response.read())
+
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            dat_files = [n for n in zf.namelist()
+                         if n.lower().endswith('.dat')]
+            if not dat_files:
+                zip_path.unlink()
+                return None
+
+            with zf.open(dat_files[0]) as src:
+                with open(dat_path, 'wb') as dst:
+                    dst.write(src.read())
+
+        zip_path.unlink()
+        return dat_path
+
+    except urllib.error.URLError:
+        return None
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+# =============================================================================
+# Region priority and selection
+# =============================================================================
+
+def get_teknoparrot_region_priority(region: str,
+                                    region_priority: List[str] = None
+                                    ) -> int:
+    """Get priority for TeknoParrot regions (lower is better)."""
+    if region_priority:
+        region_upper = region.upper()
+        for i, reg in enumerate(region_priority):
+            if reg.upper() == region_upper:
+                return i
+        return len(region_priority) + 1
+
+    priorities = {
+        'Export': 0, 'USA': 1, 'World': 2, 'Europe': 3,
+        'Asia': 4, 'Japan': 5, 'Korea': 6, 'Unknown': 10,
+    }
+    return priorities.get(region, 10)
+
+
+def select_best_teknoparrot_version(
+        games: List[TeknoParrotGameInfo],
+        region_priority: List[str] = None,
+        verbose: bool = False) -> Optional[TeknoParrotGameInfo]:
+    """Select the best version from a group of TeknoParrot ROMs.
+
+    Prioritizes by: version_tuple (desc), year (desc), region priority.
+    """
+    _ = verbose  # Reserved for future callback-based logging
+    if not games:
+        return None
+    if len(games) == 1:
+        return games[0]
+
+    def sort_key(game):
+        version_score = (tuple(-v for v in game.version_tuple)
+                         if game.version_tuple else (0,))
+        year_score = -(game.year or 0)
+        region_score = get_teknoparrot_region_priority(
+            game.region, region_priority)
+        return (version_score, year_score, region_score)
+
+    sorted_games = sorted(games, key=sort_key)
+    return sorted_games[0]
+
+
+def should_include_teknoparrot_game(
+        game: TeknoParrotGameInfo,
+        include_platforms: set = None,
+        exclude_platforms: set = None) -> Tuple[bool, str]:
+    """Determine if a TeknoParrot game should be included based on platform.
+
+    Returns (should_include, reason).
+    """
+    platform = game.platform
+
+    if exclude_platforms:
+        for excluded in exclude_platforms:
+            if excluded.lower() in platform.lower():
+                return False, f"Excluded platform: {platform}"
+
+    if not include_platforms:
+        return True, f"Platform: {platform}"
+
+    for included in include_platforms:
+        if included.lower() in platform.lower():
+            return True, f"Included platform: {platform}"
+
+    return False, f"Platform not in include list: {platform}"
+
+
+# =============================================================================
+# Network TeknoParrot filtering (standalone)
+# =============================================================================
 
 def filter_teknoparrot_network(urls, config, url_sizes=None,
                                on_progress=None):
     # type: (List[str], Config, Dict[str, int], Callable) -> FilterResult
     """Filter TeknoParrot network ROM URLs.
 
-    Args:
-        urls: List of TeknoParrot ROM URLs.
-        config: Configuration object.
-        url_sizes: Optional dict of URL -> file size.
-        on_progress: Optional callback for progress updates.
+    This is a stub that returns an empty FilterResult.
+    Use filter_teknoparrot_network_roms() for the full implementation.
+    """
+    _ = urls, config, url_sizes, on_progress
+    return FilterResult(system='teknoparrot')
+
+
+def filter_teknoparrot_network_roms(
+        rom_urls,
+        include_platforms=None,
+        exclude_platforms=None,
+        region_priority=None,
+        keep_all_versions=False,
+        include_patterns=None,
+        exclude_patterns=None,
+        url_sizes=None,
+        verbose=False,
+        no_filter=False,
+        english_only=False):
+    # type: (List[str], set, set, list, bool, list, list, dict, bool, bool, bool) -> Tuple[List[str], dict]
+    """Filter TeknoParrot network ROM URLs with TP-specific logic.
+
+    Standalone implementation extracted from the monolith.
 
     Returns:
-        FilterResult with selected/excluded TeknoParrot ROMs.
+        (selected_urls, size_info_dict)
     """
-    _ = urls, config, url_sizes, on_progress  # Will be wired later
-    return FilterResult(system='teknoparrot')
+    if url_sizes is None:
+        url_sizes = {}
+
+    effective_include = (include_platforms if include_platforms
+                         else None)
+    effective_exclude = (exclude_platforms if exclude_platforms
+                         else TEKNOPARROT_EXCLUDE_PLATFORMS)
+
+    all_roms: List[TeknoParrotGameInfo] = []
+    url_map: Dict[str, str] = {}
+    size_map: Dict[str, int] = {}
+    total_source_size = 0
+
+    for url in rom_urls:
+        filename = get_filename_from_url(url)
+        file_size = url_sizes.get(url, 0)
+        total_source_size += file_size
+
+        if not no_filter:
+            if (include_patterns
+                    and not matches_patterns(filename, include_patterns)):
+                continue
+            if (exclude_patterns
+                    and matches_patterns(filename, exclude_patterns)):
+                continue
+
+        rom_info = parse_teknoparrot_filename(filename)
+        if not rom_info:
+            continue
+
+        if not no_filter:
+            should_include, _reason = should_include_teknoparrot_game(
+                rom_info, effective_include, effective_exclude)
+            if not should_include:
+                continue
+
+        all_roms.append(rom_info)
+        url_map[filename] = url
+        size_map[filename] = file_size
+
+    if no_filter:
+        selected_urls = [url_map[rom.filename]
+                         for rom in all_roms if rom.filename in url_map]
+        selected_size = sum(
+            size_map.get(rom.filename, 0)
+            for rom in all_roms if rom.filename in url_map)
+    else:
+        grouped: Dict[str, List[TeknoParrotGameInfo]] = defaultdict(list)
+        for rom in all_roms:
+            normalized = normalize_teknoparrot_title(rom.base_title)
+            grouped[normalized].append(rom)
+
+        selected_urls = []
+        selected_size = 0
+
+        for _title, roms in grouped.items():
+            if keep_all_versions:
+                for rom in roms:
+                    if rom.filename in url_map:
+                        selected_urls.append(url_map[rom.filename])
+                        selected_size += size_map.get(rom.filename, 0)
+            else:
+                best = select_best_teknoparrot_version(
+                    roms, region_priority, verbose=verbose)
+                if not best or best.filename not in url_map:
+                    continue
+
+                if (english_only
+                        and best.region in ('Japan', 'JPN', 'Korea')):
+                    has_english = any(
+                        r.region in ('World', 'USA', 'Export',
+                                     'Unknown', '')
+                        for r in roms)
+                    if not has_english:
+                        continue
+
+                selected_urls.append(url_map[best.filename])
+                selected_size += size_map.get(best.filename, 0)
+
+    return selected_urls, {
+        'source_size': total_source_size,
+        'selected_size': selected_size,
+    }

--- a/tests/test_v2_modules.py
+++ b/tests/test_v2_modules.py
@@ -276,7 +276,8 @@ def test_dat():
     print("DAT MODULE TESTS")
     print("="*60)
 
-    from retro_refiner.dat import parse_rom_filename, normalize_title
+    from retro_refiner.filter import parse_rom_filename
+    from retro_refiner.dat import normalize_title
 
     # parse_rom_filename
     info = parse_rom_filename("Super Mario World (USA).sfc")


### PR DESCRIPTION
## Summary

Extract the full ROM filtering engine from the monolith into standalone v2 modules. ~53 functions, 4 dataclasses, 20+ regex patterns, and 3 category sets.

### Modules extracted
- **dat.py**: RomInfo, DatRomEntry, DAT parsing (XML + ClrMamePro), DAT downloading, CRC verification, title normalization, BackgroundCrcIndexer
- **filter.py**: parse_rom_filename (20 regex patterns), select_best_rom, filter_network_roms, pattern matching
- **mame.py**: MameGameInfo, catver.ini/DAT parsing, category filtering, clone selection, filter_mame_network_roms
- **teknoparrot.py**: TeknoParrotGameInfo, filename parsing, version dedup, platform filtering, filter_teknoparrot_network_roms

### Monolith dependency status
- `network.py` — fully standalone
- `scanner.py` — only `scan_local_sources` still delegates
- `dat.py`, `filter.py`, `mame.py`, `teknoparrot.py` — fully standalone
- `downloader.py` — still delegates (Step 3)

## Test plan
- [ ] `python tests/test_v2_modules.py` — 46/46
- [ ] `python tests/test_selection.py` — 300/300
- [ ] Pylint 10.00/10 on all extracted modules