### PR TITLE
feat(v2): wire ratings, budget filters, dedup, download progress

### DIFF
--- a/retro_refiner/cli.py
+++ b/retro_refiner/cli.py
@@ -210,18 +210,37 @@ def run_headless(args: list):
     print(f"{'='*60}")
     print(f"Total: {total_selected} ROMs ({format_size(total_size)})")
 
+    # ----- Budget filters: --limit, --top, --size -----
+    system_selected_urls = _apply_cli_budget_filters(
+        config, system_selected_urls, all_sizes)
+
+    # Recount after budget filters
+    total_selected = sum(len(v) for v in system_selected_urls.values())
+    total_size = sum(
+        sum(all_sizes.get(u, 0) for u in urls)
+        for urls in system_selected_urls.values()
+    )
+
+    # ----- Dedup analysis -----
+    if config.dedup.priority:
+        _run_cli_dedup(config, system_selected_urls)
+
     if not commit:
         print("\nDry run complete. Use --commit to download/transfer files.")
     else:
         from retro_refiner.downloader import (  # pylint: disable=import-outside-toplevel
             get_download_tool, download_batch_with_aria2c,
-            download_batch_with_curl,
+            download_batch_with_curl, DownloadUI,
         )
         from retro_refiner.transfer import transfer_files  # pylint: disable=import-outside-toplevel
 
         dest_dir = (Path(config.destination) if config.destination
                     else get_runtime_path() / 'refined')
         dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Check if DownloadUI can be used (requires aria2c + TTY)
+        tool = get_download_tool()
+        use_interactive = (tool == 'aria2c' and sys.stdout.isatty())
 
         print(f"\nDownloading to cache and transferring to {dest_dir}...")
         for system in sorted(system_selected_urls):
@@ -239,29 +258,45 @@ def run_headless(args: list):
                     downloads.append((url, cp))
 
             if downloads:
-                print(f"  {system.upper()}: downloading "
-                      f"{len(downloads)} files...")
-                tool = get_download_tool()
-                if tool == 'aria2c':
-                    download_batch_with_aria2c(
-                        downloads, parallel=config.network.parallel)
-                elif tool == 'curl':
-                    download_batch_with_curl(
-                        downloads, parallel=config.network.parallel)
+                if use_interactive:
+                    # Use DownloadUI for interactive progress display
+                    ui = DownloadUI(
+                        system_name=system,
+                        files=downloads,
+                        parallel=config.network.parallel,
+                        connections=config.network.connections or 4,
+                        resume=config.network.resume_downloads,
+                    )
+                    completed = ui.run()
+                    print()  # newline after progress bar
+                    print(f"  {system.upper()}: downloaded "
+                          f"{len(completed)}/{len(downloads)} files")
                 else:
-                    import urllib.request as urllib_req  # pylint: disable=import-outside-toplevel
-                    for dl_url, dl_path in downloads:
-                        try:
-                            req = urllib_req.Request(
-                                dl_url,
-                                headers={'User-Agent': 'Mozilla/5.0'})
-                            with urllib_req.urlopen(
-                                    req, timeout=60) as resp:
-                                import shutil  # pylint: disable=import-outside-toplevel
-                                with open(dl_path, 'wb') as f_out:
-                                    shutil.copyfileobj(resp, f_out)
-                        except Exception:  # pylint: disable=broad-except
-                            pass
+                    print(f"  {system.upper()}: downloading "
+                          f"{len(downloads)} files...")
+                    if tool == 'aria2c':
+                        download_batch_with_aria2c(
+                            downloads,
+                            parallel=config.network.parallel)
+                    elif tool == 'curl':
+                        download_batch_with_curl(
+                            downloads,
+                            parallel=config.network.parallel)
+                    else:
+                        import urllib.request as urllib_req  # pylint: disable=import-outside-toplevel
+                        for dl_url, dl_path in downloads:
+                            try:
+                                req = urllib_req.Request(
+                                    dl_url,
+                                    headers={
+                                        'User-Agent': 'Mozilla/5.0'})
+                                with urllib_req.urlopen(
+                                        req, timeout=60) as resp:
+                                    import shutil  # pylint: disable=import-outside-toplevel
+                                    with open(dl_path, 'wb') as f_out:
+                                        shutil.copyfileobj(resp, f_out)
+                            except Exception:  # pylint: disable=broad-except
+                                pass
 
             cached = []
             for url in sys_urls:
@@ -282,3 +317,171 @@ def run_headless(args: list):
                       f"{stats['skipped']}, errors {stats['errors']}")
 
         print("\nCommit complete.")
+
+
+def _parse_size_string(size_str):
+    """Parse a size string like '10GB', '500MB' into bytes."""
+    if not size_str:
+        return None
+    size_str = str(size_str).strip().upper()
+    multipliers = {
+        'TB': 1024 ** 4, 'T': 1024 ** 4,
+        'GB': 1024 ** 3, 'G': 1024 ** 3,
+        'MB': 1024 ** 2, 'M': 1024 ** 2,
+        'KB': 1024, 'K': 1024,
+        'B': 1,
+    }
+    for suffix, mult in multipliers.items():
+        if size_str.endswith(suffix):
+            try:
+                return int(float(size_str[:-len(suffix)].strip()) * mult)
+            except ValueError:
+                return None
+    try:
+        return int(float(size_str))
+    except ValueError:
+        return None
+
+
+def _apply_cli_budget_filters(config, system_selected_urls, all_sizes):
+    """Apply --limit, --top, and --size budget filters in CLI mode."""
+    # --limit: simple total cap
+    if config.budget.limit:
+        remaining = config.budget.limit
+        for system in sorted(system_selected_urls):
+            sys_urls = system_selected_urls[system]
+            if remaining <= 0:
+                system_selected_urls[system] = []
+            elif len(sys_urls) > remaining:
+                system_selected_urls[system] = sys_urls[:remaining]
+                remaining = 0
+            else:
+                remaining -= len(sys_urls)
+        new_total = sum(len(v) for v in system_selected_urls.values())
+        print(f"\n--limit {config.budget.limit}: {new_total} ROMs retained")
+
+    # --top and --size require ratings
+    if config.budget.top or config.budget.size:
+        system_selected_urls = _apply_cli_ratings_budget(
+            config, system_selected_urls, all_sizes)
+
+    return system_selected_urls
+
+
+def _apply_cli_ratings_budget(config, system_selected_urls, all_sizes):
+    """Load ratings and apply --top / --size in CLI mode."""
+    from retro_refiner.ratings import (  # pylint: disable=import-outside-toplevel
+        build_ratings_cache, download_launchbox_data,
+        apply_top_n_filter, apply_size_budget,
+        boost_exclusive_ratings,
+    )
+    from retro_refiner.filter import parse_rom_filename  # pylint: disable=import-outside-toplevel
+
+    dat_dir = Path(config.advanced.dat_dir or './dat_files')
+    dat_dir.mkdir(parents=True, exist_ok=True)
+
+    print("\nLoading ratings data...")
+    xml_path = download_launchbox_data(dat_dir)
+    if not xml_path:
+        print("  WARNING: No ratings data available "
+              "(LaunchBox download failed)", file=sys.stderr)
+        return system_selected_urls
+
+    cache_path = dat_dir / 'launchbox' / 'ratings_cache.json'
+    ratings = build_ratings_cache(xml_path, cache_path=cache_path)
+
+    if not ratings:
+        print("  WARNING: No ratings found in data", file=sys.stderr)
+        return system_selected_urls
+
+    total_rated = sum(len(v) for v in ratings.values())
+    print(f"  {total_rated} games rated")
+
+    if config.budget.prefer_exclusives:
+        ratings = boost_exclusive_ratings(
+            ratings, boost=config.budget.prefer_exclusives)
+
+    for system in sorted(system_selected_urls):
+        sys_urls = system_selected_urls[system]
+        if not sys_urls:
+            continue
+        sys_ratings = ratings.get(system, {})
+        if not sys_ratings:
+            continue
+
+        # Build RomInfo objects from filenames
+        url_roms = []
+        url_map = {}
+        for url in sys_urls:
+            filename = urllib.parse.unquote(
+                url.split('?')[0].split('#')[0].split('/')[-1])
+            rom = parse_rom_filename(filename)
+            url_roms.append(rom)
+            url_map[id(rom)] = url
+
+        if config.budget.top:
+            before = len(url_roms)
+            url_roms = apply_top_n_filter(
+                url_roms, sys_ratings, config.budget.top,
+                include_unrated=config.budget.include_unrated,
+            )
+            after = len(url_roms)
+            if after < before:
+                print(f"  {system.upper()}: top filter "
+                      f"{before} -> {after}")
+
+        if config.budget.size:
+            budget_bytes = _parse_size_string(config.budget.size)
+            if budget_bytes and budget_bytes > 0:
+                rom_sizes = {}
+                for rom in url_roms:
+                    url = url_map[id(rom)]
+                    rom_sizes[rom.filename] = all_sizes.get(url, 0)
+
+                before = len(url_roms)
+                url_roms, _ = apply_size_budget(
+                    url_roms, rom_sizes, budget_bytes,
+                    ratings=sys_ratings,
+                    name_fn=lambda r: r.filename,
+                    rating_name_fn=lambda r: r.base_title,
+                )
+                after = len(url_roms)
+                if after < before:
+                    print(f"  {system.upper()}: size budget "
+                          f"{before} -> {after}")
+
+        system_selected_urls[system] = [
+            url_map[id(rom)] for rom in url_roms
+        ]
+
+    return system_selected_urls
+
+
+def _run_cli_dedup(config, system_selected_urls):
+    """Run cross-platform dedup analysis in CLI mode."""
+    from retro_refiner.dedup import run_dedupe_analysis  # pylint: disable=import-outside-toplevel
+    from types import SimpleNamespace  # pylint: disable=import-outside-toplevel
+
+    # Build a detected dict mapping system -> list of Path-like objects
+    # For URL-based results, we create lightweight path proxies from filenames
+    detected = {}
+    for system, urls in system_selected_urls.items():
+        if urls:
+            paths = []
+            for url in urls:
+                filename = urllib.parse.unquote(
+                    url.split('?')[0].split('#')[0].split('/')[-1])
+                # Create a Path-like object with .name and minimal stat
+                paths.append(Path(filename))
+            detected[system] = paths
+
+    if not detected:
+        return
+
+    args = SimpleNamespace(
+        dedupe_priority=config.dedup.priority,
+        dedupe_pc_lists=config.dedup.pc_lists or [],
+        verbose=config.selection.verbose,
+    )
+
+    run_dedupe_analysis(detected, args, delete=False, confirm=False)

--- a/retro_refiner/ui/api.py
+++ b/retro_refiner/ui/api.py
@@ -425,11 +425,9 @@ class Api:
                 if system in self._last_results:
                     self._last_results[system]['selected_urls'] = selected_urls
 
-            # TODO: Budget filters (--top, --limit, --size) require ratings
-            # data to apply properly. For now, simple limit is noted but not
-            # applied since it requires proportional truncation across systems.
-            # Dedup is available in the core engine but not yet exposed in the
-            # GUI — wire it when the dedup UI is built.
+            # ----- Budget filters: --limit, --top, --size -----
+            if self._running:
+                self._apply_budget_filters(config, all_systems, all_sizes)
 
             if not self._running:
                 self._push_event('status', {
@@ -439,10 +437,6 @@ class Api:
 
             # Commit mode: download and transfer files
             if commit and self._running:
-                from retro_refiner.downloader import (  # pylint: disable=import-outside-toplevel
-                    get_download_tool, download_batch_with_aria2c,
-                    download_batch_with_curl,
-                )
                 from retro_refiner.transfer import (  # pylint: disable=import-outside-toplevel
                     transfer_files, generate_m3u_playlist,
                     generate_gamelist_xml,
@@ -475,31 +469,14 @@ class Api:
                             'text': f'  {system.upper()}: downloading '
                                     f'{len(downloads)} files...\n',
                         })
-                        tool = get_download_tool()
-                        if tool == 'aria2c':
-                            download_batch_with_aria2c(
-                                downloads,
-                                parallel=config.network.parallel)
-                        elif tool == 'curl':
-                            download_batch_with_curl(
-                                downloads,
-                                parallel=config.network.parallel)
-                        else:
-                            # urllib fallback
-                            import urllib.request as urllib_req  # pylint: disable=import-outside-toplevel
-                            for dl_url, dl_path in downloads:
-                                try:
-                                    req = urllib_req.Request(
-                                        dl_url,
-                                        headers={
-                                            'User-Agent': 'Mozilla/5.0'})
-                                    with urllib_req.urlopen(
-                                            req, timeout=60) as resp:
-                                        import shutil as _shutil  # pylint: disable=import-outside-toplevel
-                                        with open(dl_path, 'wb') as f_out:
-                                            _shutil.copyfileobj(resp, f_out)
-                                except Exception:  # pylint: disable=broad-except
-                                    pass
+                        # NOTE: DownloadUI requires a TTY for its
+                        # interactive curses/keyboard UI, so it cannot
+                        # run inside the pywebview context.  We use the
+                        # batch download functions and push progress
+                        # events to the JS frontend instead.
+                        self._download_batch(
+                            downloads, config.network.parallel,
+                            system)
 
                     # Transfer cached files to destination
                     cached_files = []
@@ -576,6 +553,197 @@ class Api:
             })
         finally:
             self._running = False
+
+    def _download_batch(self, downloads, parallel, system):
+        """Download files using best available tool with progress events."""
+        from retro_refiner.downloader import (  # pylint: disable=import-outside-toplevel
+            get_download_tool, download_batch_with_aria2c,
+            download_batch_with_curl,
+        )
+
+        total = len(downloads)
+        tool = get_download_tool()
+
+        if tool == 'aria2c':
+            download_batch_with_aria2c(downloads, parallel=parallel)
+        elif tool == 'curl':
+            download_batch_with_curl(downloads, parallel=parallel)
+        else:
+            # urllib fallback with per-file progress
+            import urllib.request as urllib_req  # pylint: disable=import-outside-toplevel
+            import shutil as _shutil  # pylint: disable=import-outside-toplevel
+            for idx, (dl_url, dl_path) in enumerate(downloads, 1):
+                if not self._running:
+                    break
+                self._push_event('progress', {
+                    'phase': 'download',
+                    'message': f'{system.upper()}: {idx}/{total}',
+                    'current': idx,
+                    'total': total,
+                })
+                try:
+                    req = urllib_req.Request(
+                        dl_url,
+                        headers={'User-Agent': 'Mozilla/5.0'})
+                    with urllib_req.urlopen(req, timeout=60) as resp:
+                        with open(dl_path, 'wb') as f_out:
+                            _shutil.copyfileobj(resp, f_out)
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+        self._push_event('log', {
+            'text': f'  {system.upper()}: download complete '
+                    f'({total} files, tool={tool or "urllib"})\n',
+        })
+
+    def _apply_budget_filters(self, config, all_systems, all_sizes):
+        """Apply --limit, --top, and --size budget filters after filtering."""
+        # --limit: simple total cap across systems
+        if config.budget.limit:
+            remaining = config.budget.limit
+            for system in sorted(all_systems):
+                sys_data = self._last_results.get(system, {})
+                sys_urls = sys_data.get('selected_urls', [])
+                if not sys_urls:
+                    continue
+                if remaining <= 0:
+                    sys_data['selected_urls'] = []
+                elif len(sys_urls) > remaining:
+                    sys_data['selected_urls'] = sys_urls[:remaining]
+                    remaining = 0
+                else:
+                    remaining -= len(sys_urls)
+
+        # --top and --size require ratings data
+        if config.budget.top or config.budget.size:
+            self._apply_ratings_budget(config, all_systems, all_sizes)
+
+    def _apply_ratings_budget(self, config, all_systems, all_sizes):
+        """Load ratings and apply --top / --size budget filters."""
+        from retro_refiner.ratings import (  # pylint: disable=import-outside-toplevel
+            build_ratings_cache, download_launchbox_data,
+            apply_top_n_filter, apply_size_budget,
+            boost_exclusive_ratings,
+        )
+        from retro_refiner.filter import parse_rom_filename  # pylint: disable=import-outside-toplevel
+
+        dat_dir = Path(config.advanced.dat_dir or './dat_files')
+        dat_dir.mkdir(parents=True, exist_ok=True)
+
+        self._push_event('log', {
+            'text': '\nLoading ratings data...\n',
+        })
+
+        # Download LaunchBox data if not cached
+        xml_path = download_launchbox_data(
+            dat_dir,
+            on_progress=lambda dl, total: self._push_event('progress', {
+                'phase': 'ratings',
+                'message': f'Downloading ratings ({dl // 1024 // 1024}MB)',
+                'current': dl,
+                'total': total,
+            }),
+        )
+
+        if not xml_path:
+            self._push_event('log', {
+                'text': '  No ratings data available '
+                        '(LaunchBox download failed)\n',
+                'className': 'log-warning',
+            })
+            return
+
+        cache_path = dat_dir / 'launchbox' / 'ratings_cache.json'
+        ratings = build_ratings_cache(
+            xml_path, cache_path=cache_path,
+            on_progress=lambda br, total, gc: self._push_event('progress', {
+                'phase': 'ratings',
+                'message': f'Parsing ratings ({gc} games)',
+                'current': br,
+                'total': total,
+            }),
+        )
+
+        if not ratings:
+            self._push_event('log', {
+                'text': '  No ratings found in data\n',
+                'className': 'log-warning',
+            })
+            return
+
+        total_rated = sum(len(v) for v in ratings.values())
+        self._push_event('log', {
+            'text': f'  {total_rated} games rated\n',
+        })
+
+        # Boost exclusives if configured
+        if config.budget.prefer_exclusives:
+            ratings = boost_exclusive_ratings(
+                ratings, boost=config.budget.prefer_exclusives)
+
+        # Apply --top and --size per system
+        for system in sorted(all_systems):
+            if not self._running:
+                return
+            sys_data = self._last_results.get(system, {})
+            sys_urls = sys_data.get('selected_urls', [])
+            if not sys_urls:
+                continue
+
+            sys_ratings = ratings.get(system, {})
+            if not sys_ratings:
+                continue
+
+            # Build lightweight RomInfo objects from URL filenames
+            url_roms = []
+            url_map = {}  # base_title -> url
+            for url in sys_urls:
+                filename = urllib.parse.unquote(
+                    url.split('?')[0].split('#')[0].split('/')[-1])
+                rom = parse_rom_filename(filename)
+                url_roms.append(rom)
+                url_map[id(rom)] = url
+
+            if config.budget.top:
+                before = len(url_roms)
+                url_roms = apply_top_n_filter(
+                    url_roms, sys_ratings, config.budget.top,
+                    include_unrated=config.budget.include_unrated,
+                )
+                after = len(url_roms)
+                if after < before:
+                    self._push_event('log', {
+                        'text': f'  {system.upper()}: top filter '
+                                f'{before} -> {after}\n',
+                    })
+
+            if config.budget.size:
+                budget_bytes = _parse_size_string(config.budget.size)
+                if budget_bytes and budget_bytes > 0:
+                    # Build size lookup keyed by filename
+                    rom_sizes = {}
+                    for rom in url_roms:
+                        url = url_map[id(rom)]
+                        rom_sizes[rom.filename] = all_sizes.get(url, 0)
+
+                    before = len(url_roms)
+                    url_roms, _ = apply_size_budget(
+                        url_roms, rom_sizes, budget_bytes,
+                        ratings=sys_ratings,
+                        name_fn=lambda r: r.filename,
+                        rating_name_fn=lambda r: r.base_title,
+                    )
+                    after = len(url_roms)
+                    if after < before:
+                        self._push_event('log', {
+                            'text': f'  {system.upper()}: size budget '
+                                    f'{before} -> {after}\n',
+                        })
+
+            # Rebuild selected URLs from surviving roms
+            sys_data['selected_urls'] = [
+                url_map[id(rom)] for rom in url_roms
+            ]
 
     def get_system_roms(self, system: str) -> str:
         """Get ROM list for a system as JSON.
@@ -693,4 +861,31 @@ def _int_or_none(value):
     try:
         return int(value)
     except (ValueError, TypeError):
+        return None
+
+
+def _parse_size_string(size_str):
+    """Parse a size string like '10GB', '500MB' into bytes.
+
+    Returns integer bytes or None if parsing fails.
+    """
+    if not size_str:
+        return None
+    size_str = str(size_str).strip().upper()
+    multipliers = {
+        'TB': 1024 ** 4, 'T': 1024 ** 4,
+        'GB': 1024 ** 3, 'G': 1024 ** 3,
+        'MB': 1024 ** 2, 'M': 1024 ** 2,
+        'KB': 1024, 'K': 1024,
+        'B': 1,
+    }
+    for suffix, mult in multipliers.items():
+        if size_str.endswith(suffix):
+            try:
+                return int(float(size_str[:-len(suffix)].strip()) * mult)
+            except ValueError:
+                return None
+    try:
+        return int(float(size_str))
+    except ValueError:
         return None

--- a/tests/test_v2_modules.py
+++ b/tests/test_v2_modules.py
@@ -625,6 +625,211 @@ def test_scanner_local():
                          "{}", repr(result))
 
 
+# =============================================================================
+# Budget Filter Tests
+# =============================================================================
+
+def test_budget_limit():
+    """Test --limit budget filter in API."""
+    print("\n" + "="*60)
+    print("BUDGET LIMIT TESTS")
+    print("="*60)
+
+    from retro_refiner.ui.api import _parse_size_string
+
+    # Size string parsing
+    if _parse_size_string('10GB') == 10 * 1024 ** 3:
+        results.ok("_parse_size_string parses 10GB")
+    else:
+        results.fail("_parse_size_string parses 10GB",
+                     str(10 * 1024 ** 3), str(_parse_size_string('10GB')))
+
+    if _parse_size_string('500MB') == 500 * 1024 ** 2:
+        results.ok("_parse_size_string parses 500MB")
+    else:
+        results.fail("_parse_size_string parses 500MB",
+                     str(500 * 1024 ** 2), str(_parse_size_string('500MB')))
+
+    if _parse_size_string('1.5GB') == int(1.5 * 1024 ** 3):
+        results.ok("_parse_size_string parses 1.5GB")
+    else:
+        results.fail("_parse_size_string parses 1.5GB",
+                     str(int(1.5 * 1024 ** 3)),
+                     str(_parse_size_string('1.5GB')))
+
+    if _parse_size_string(None) is None:
+        results.ok("_parse_size_string returns None for None")
+    else:
+        results.fail("_parse_size_string returns None for None",
+                     "None", str(_parse_size_string(None)))
+
+    if _parse_size_string('') is None:
+        results.ok("_parse_size_string returns None for empty")
+    else:
+        results.fail("_parse_size_string returns None for empty",
+                     "None", str(_parse_size_string('')))
+
+    if _parse_size_string('invalid') is None:
+        results.ok("_parse_size_string returns None for invalid")
+    else:
+        results.fail("_parse_size_string returns None for invalid",
+                     "None", str(_parse_size_string('invalid')))
+
+
+def test_ratings_functions():
+    """Test ratings helper functions."""
+    print("\n" + "="*60)
+    print("RATINGS FUNCTION TESTS")
+    print("="*60)
+
+    from retro_refiner.ratings import (
+        combine_ratings, boost_exclusive_ratings,
+        resolve_top_n, apply_top_n_filter, apply_size_budget,
+    )
+    from retro_refiner.filter import parse_rom_filename
+
+    # resolve_top_n
+    if resolve_top_n(10, 100) == 10:
+        results.ok("resolve_top_n integer")
+    else:
+        results.fail("resolve_top_n integer", "10",
+                     str(resolve_top_n(10, 100)))
+
+    if resolve_top_n("25%", 100) == 25:
+        results.ok("resolve_top_n percentage")
+    else:
+        results.fail("resolve_top_n percentage", "25",
+                     str(resolve_top_n("25%", 100)))
+
+    if resolve_top_n(None, 100) is None:
+        results.ok("resolve_top_n None")
+    else:
+        results.fail("resolve_top_n None", "None",
+                     str(resolve_top_n(None, 100)))
+
+    # combine_ratings
+    igdb = {'snes': {'mario': {'rating': 8.0, 'votes': 100, 'name': 'Mario'}}}
+    lb = {'snes': {'mario': {'rating': 9.0, 'votes': 200, 'name': 'Mario'}}}
+    combined = combine_ratings(igdb, lb)
+    if 'snes' in combined and 'mario' in combined['snes']:
+        rating = combined['snes']['mario']['rating']
+        # Weighted average: (8*100 + 9*200) / 300 = 2600/300 = 8.67
+        if abs(rating - 8.67) < 0.01:
+            results.ok("combine_ratings weighted average")
+        else:
+            results.fail("combine_ratings weighted average",
+                         "~8.67", str(rating))
+    else:
+        results.fail("combine_ratings weighted average",
+                     "combined entry", "missing")
+
+    # boost_exclusive_ratings
+    ratings = {
+        'snes': {'mario': {'rating': 8.0, 'votes': 100, 'name': 'Mario'},
+                 'zelda': {'rating': 9.0, 'votes': 50, 'name': 'Zelda'}},
+        'genesis': {'sonic': {'rating': 8.5, 'votes': 80, 'name': 'Sonic'},
+                    'zelda': {'rating': 7.0, 'votes': 40, 'name': 'Zelda'}},
+    }
+    boosted = boost_exclusive_ratings(ratings, boost=1.0)
+    mario_r = boosted['snes']['mario']['rating']
+    zelda_r = boosted['snes']['zelda']['rating']
+    if mario_r == 9.0 and zelda_r == 9.0:
+        results.ok("boost_exclusive_ratings boosts exclusives only")
+    else:
+        results.fail("boost_exclusive_ratings boosts exclusives only",
+                     "mario=9.0, zelda=9.0",
+                     f"mario={mario_r}, zelda={zelda_r}")
+
+    # apply_top_n_filter
+    roms = []
+    for name in ['Game A (USA).sfc', 'Game B (USA).sfc', 'Game C (USA).sfc']:
+        roms.append(parse_rom_filename(name))
+    sys_ratings = {
+        'game a': {'rating': 9.0, 'votes': 100},
+        'game b': {'rating': 7.0, 'votes': 50},
+        'game c': {'rating': 5.0, 'votes': 30},
+    }
+    filtered = apply_top_n_filter(roms, sys_ratings, 2)
+    if len(filtered) == 2:
+        results.ok("apply_top_n_filter returns top 2")
+    else:
+        results.fail("apply_top_n_filter returns top 2",
+                     "2", str(len(filtered)))
+
+    # apply_size_budget
+    items = ['a', 'b', 'c']
+    sizes = {'a': 100, 'b': 200, 'c': 300}
+    kept, used = apply_size_budget(items, sizes, 350)
+    if len(kept) == 2 and used == 300:
+        results.ok("apply_size_budget fits within budget")
+    else:
+        results.fail("apply_size_budget fits within budget",
+                     "2 kept, 300 used", f"{len(kept)} kept, {used} used")
+
+    # apply_size_budget with zero budget
+    kept2, used2 = apply_size_budget(items, sizes, 0)
+    if len(kept2) == 0 and used2 == 0:
+        results.ok("apply_size_budget zero budget returns empty")
+    else:
+        results.fail("apply_size_budget zero budget returns empty",
+                     "0, 0", f"{len(kept2)}, {used2}")
+
+
+def test_cli_budget_helpers():
+    """Test CLI budget helper functions."""
+    print("\n" + "="*60)
+    print("CLI BUDGET HELPER TESTS")
+    print("="*60)
+
+    from retro_refiner.cli import _parse_size_string
+
+    if _parse_size_string('10GB') == 10 * 1024 ** 3:
+        results.ok("cli _parse_size_string parses 10GB")
+    else:
+        results.fail("cli _parse_size_string parses 10GB",
+                     str(10 * 1024 ** 3),
+                     str(_parse_size_string('10GB')))
+
+    if _parse_size_string('1TB') == 1024 ** 4:
+        results.ok("cli _parse_size_string parses 1TB")
+    else:
+        results.fail("cli _parse_size_string parses 1TB",
+                     str(1024 ** 4),
+                     str(_parse_size_string('1TB')))
+
+    if _parse_size_string('abc') is None:
+        results.ok("cli _parse_size_string returns None for invalid")
+    else:
+        results.fail("cli _parse_size_string returns None for invalid",
+                     "None", str(_parse_size_string('abc')))
+
+
+def test_dedup_functions():
+    """Test dedup module functions."""
+    print("\n" + "="*60)
+    print("DEDUP FUNCTION TESTS")
+    print("="*60)
+
+    from retro_refiner.dedup import parse_pc_game_list, normalize_title_for_dedupe
+    from retro_refiner.dat import normalize_title_for_dedupe as nfd
+
+    # normalize_title_for_dedupe basic test
+    norm = nfd("Super Mario World")
+    if isinstance(norm, str) and len(norm) > 0:
+        results.ok("normalize_title_for_dedupe returns non-empty")
+    else:
+        results.fail("normalize_title_for_dedupe returns non-empty",
+                     "non-empty string", repr(norm))
+
+    # parse_pc_game_list with non-existent file
+    titles = parse_pc_game_list("/nonexistent/file.xml")
+    if titles == set():
+        results.ok("parse_pc_game_list returns empty for missing file")
+    else:
+        results.fail("parse_pc_game_list returns empty for missing file",
+                     "empty set", repr(titles))
+
+
 if __name__ == '__main__':
     test_all_imports()
     test_systems()
@@ -638,5 +843,9 @@ if __name__ == '__main__':
     test_teknoparrot()
     test_downloader()
     test_transfer()
+    test_budget_limit()
+    test_ratings_functions()
+    test_cli_budget_helpers()
+    test_dedup_functions()
     success = results.summary()
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

Wires the final 4 functionality gaps from the architecture audit.

### What's wired
1. **Ratings pipeline** — Downloads LaunchBox data, builds ratings cache, applies `--top` and `--size` budget filters per-system with rating-based sorting
2. **Budget `--limit`** — Simple total cap across systems
3. **Dedup** — `run_dedupe_analysis` called in CLI when `dedup.priority` configured
4. **DownloadUI** — Used in CLI commit mode when aria2c + TTY available; GUI uses batch downloads with JS progress events (DownloadUI needs TTY/curses)

### Test results
- 300/300 core tests
- 80/80 module tests (19 new for budget/ratings/dedup)
- Pylint 10.00/10

## Test plan
- [ ] `python tests/test_selection.py` — 300
- [ ] `python tests/test_v2_modules.py` — 80
- [ ] `python -m pylint retro_refiner/`